### PR TITLE
two features

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -66,9 +66,13 @@ func (e Encoder) Encode(dst interface{}) error {
 }
 
 // EncodeToString encodes dst as a form and returns it as a string.
-func EncodeToString(dst interface{}) (string, error) {
+func EncodeToString(dst interface{}, needEmptyValue ...bool) (string, error) {
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, false)
+	z := false
+	if len(needEmptyValue) != 0 {
+		z = needEmptyValue[0]
+	}
+	n, err := encodeToNode(v, z)
 	if err != nil {
 		return "", err
 	}
@@ -77,9 +81,13 @@ func EncodeToString(dst interface{}) (string, error) {
 }
 
 // EncodeToValues encodes dst as a form and returns it as Values.
-func EncodeToValues(dst interface{}) (url.Values, error) {
+func EncodeToValues(dst interface{}, needEmptyValue ...bool) (url.Values, error) {
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, false)
+	z := false
+	if len(needEmptyValue) != 0 {
+		z = needEmptyValue[0]
+	}
+	n, err := encodeToNode(v, z)
 	if err != nil {
 		return nil, err
 	}

--- a/encode.go
+++ b/encode.go
@@ -268,15 +268,23 @@ func canIndexOrdinally(v reflect.Value) bool {
 	return false
 }
 
-func fieldInfo(f reflect.StructField) (k string, oe bool) {
+func fieldInfo(f reflect.StructField, tagName ...string) (k string, oe bool) {
+	_tagName := "form"
+	if len(tagName) > 0 {
+		_tagName = tagName[0]
+	}
 	if f.PkgPath != "" { // Skip private fields.
 		return omittedKey, oe
 	}
 
 	k = f.Name
-	tag := f.Tag.Get("form")
+	tag := f.Tag.Get(_tagName)
 	if tag == "" {
-		return k, oe
+		if len(tagName) == 0 {
+			return fieldInfo(f, "json") // using json as secondary
+		} else {
+			return k, oe
+		}
 	}
 
 	ps := strings.SplitN(tag, ",", 2)

--- a/encode.go
+++ b/encode.go
@@ -280,7 +280,7 @@ func fieldInfo(f reflect.StructField, tagName ...string) (k string, oe bool) {
 	k = f.Name
 	tag := f.Tag.Get(_tagName)
 	if tag == "" {
-		if len(tagName) == 0 {
+		if len(tagName) == 0 && _tagName != "json" {
 			return fieldInfo(f, "json") // using json as secondary
 		} else {
 			return k, oe


### PR DESCRIPTION
EncodeToString, remain 'null' value:
```
{“test1”: 0, “test2”: false} EncodeToString
from
test1=&test2=
change to
test1=0&test2=false
```
fieldInfo: using 'json' tag as second choice:
using 'form' as default tag, using 'json' tag when there's no 'form' tag.