### PR TITLE
Fix empty struct checks after change in Go 1.16

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -249,7 +249,7 @@ func isEmptyValue(v reflect.Value) bool {
 		if t.ConvertibleTo(timeType) {
 			return v.Convert(timeType).Interface().(time.Time).IsZero()
 		}
-		return reflect.DeepEqual(v, reflect.Zero(t))
+		return t.NumField() == 0
 	}
 	return false
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -64,6 +64,16 @@ type Thing4 struct {
 	Integer uint   `form:"num"`
 }
 
+type Thing5 struct {
+	Struct    struct{}            `form:"struct,omitempty"`
+	MapStruct map[string]struct{} `form:"mapstruct,omitempty"`
+}
+
+type Thing6 struct {
+	Struct    struct{}            `form:"struct"`
+	MapStruct map[string]struct{} `form:"mapstruct"`
+}
+
 func TestEncode_KeepZero(t *testing.T) {
 	num := uint(0)
 	for _, c := range []struct {
@@ -79,6 +89,10 @@ func TestEncode_KeepZero(t *testing.T) {
 		{Thing3{"test", &num}, "name=test&num=0", true},
 		{Thing4{"test", num}, "name=test&num=", false},
 		{Thing4{"test", num}, "name=test&num=0", true},
+		{Thing5{struct{}{}, map[string]struct{}{"x": {}}}, "mapstruct.x=", false},
+		{Thing5{struct{}{}, map[string]struct{}{"x": {}}}, "mapstruct.x=", true},
+		{Thing6{struct{}{}, map[string]struct{}{"x": {}}}, "mapstruct.x=&struct=", false},
+		{Thing6{struct{}{}, map[string]struct{}{"x": {}}}, "mapstruct.x=&struct=", true},
 		{Thing1{"", &num}, "num=", false},
 		{Thing1{"", &num}, "num=0", true},
 		{Thing2{"", num}, "", false},
@@ -87,6 +101,10 @@ func TestEncode_KeepZero(t *testing.T) {
 		{Thing3{"", &num}, "name=&num=0", true},
 		{Thing4{"", num}, "name=&num=", false},
 		{Thing4{"", num}, "name=&num=0", true},
+		{Thing5{struct{}{}, map[string]struct{}{}}, "", false},
+		{Thing5{struct{}{}, map[string]struct{}{}}, "", true},
+		{Thing6{struct{}{}, map[string]struct{}{}}, "mapstruct=&struct=", false},
+		{Thing6{struct{}{}, map[string]struct{}{}}, "mapstruct=&struct=", true},
 	} {
 
 		var w bytes.Buffer

--- a/node.go
+++ b/node.go
@@ -24,7 +24,11 @@ func (n node) merge(d, e rune, p string, vs *url.Values) {
 		case string:
 			vs.Add(p+escape(d, e, k), y)
 		case node:
-			y.merge(d, e, p+escape(d, e, k)+string(d), vs)
+			if len(y) == 0 {
+				vs.Add(p+escape(d, e, k), "")
+			} else {
+				y.merge(d, e, p+escape(d, e, k)+string(d), vs)
+			}
 		default:
 			panic("value is neither string nor node")
 		}


### PR DESCRIPTION
The previous verification for empty structs was invalid and only worked by chance for structs with no fields. After the change in Go 1.16 described in https://github.com/golang/go/issues/43993 this verification stopped working.

This PR changes how empty structs are handled and also adds new test cases to ensure that this behavior is now consistent.