### PR TITLE
Remove test cases that are no longer valid with go 1.17

### DIFF
--- a/form_test.go
+++ b/form_test.go
@@ -126,7 +126,6 @@ func testCases(dir direction) (cs []testCase) {
 	var T time.Time
 	var U url.URL
 	const canonical = `A.0=x&A.1=y&A.2=z&B=true&C=42%2B6.6i&E.Bytes1=%00%01%02&E.Bytes2=%03%04%05&F=6.6&M.Bar=8&M.Foo=7&M.Qux=9&P%5C.D%5C%5CQ%5C.B.A=P%2FD&P%5C.D%5C%5CQ%5C.B.B=Q-B&R=8734&S=Hello%2C+there.&T=2013-10-01T07%3A05%3A34.000000088Z&U=http%3A%2F%2Fexample.org%2Ffoo%23bar&Zs.0.Q=11_22&Zs.0.Qp=33_44&Zs.0.Z=2006-12-01&life=42`
-	const variation = `;C=42%2B6.6i;A.0=x;M.Bar=8;F=6.6;A.1=y;R=8734;A.2=z;Zs.0.Qp=33_44;B=true;M.Foo=7;T=2013-10-01T07:05:34.000000088Z;E.Bytes1=%00%01%02;Bytes2=%03%04%05;Zs.0.Q=11_22;Zs.0.Z=2006-12-01;M.Qux=9;life=42;S=Hello,+there.;P\.D\\Q\.B.A=P/D;P\.D\\Q\.B.B=Q-B;U=http%3A%2F%2Fexample.org%2Ffoo%23bar;`
 
 	for _, c := range []testCase{
 		// Bools
@@ -196,26 +195,6 @@ func testCases(dir direction) (cs []testCase) {
 				P{"P/D", "Q-B"},
 			},
 		},
-		{decOnly, &Struct{Y: 786}, variation,
-			&Struct{
-				true,
-				42,
-				6.6,
-				complex(42, 6.6),
-				'\u221E',
-				rune(0),
-				"Hello, there.",
-				time.Date(2013, 10, 1, 7, 5, 34, 88, time.UTC),
-				url.URL{Scheme: "http", Host: "example.org", Path: "/foo", Fragment: "bar"},
-				Array{"x", "y", "z"},
-				Map{"Foo": 7, "Bar": 8, "Qux": 9},
-				786, // Y: This value should not change.
-				nil, // Ye: This value should not change.
-				Slice{{Z(time.Date(2006, 12, 1, 0, 0, 0, 0, time.UTC)), Q{11, 22}, &Q{33, 44}, Q{}, E{}}},
-				E{[]byte{0, 1, 2}, []byte{3, 4, 5}},
-				P{"P/D", "Q-B"},
-			},
-		},
 
 		// Maps
 		{rndTrip, prepopulate(SXs{}), canonical,
@@ -234,26 +213,6 @@ func testCases(dir direction) (cs []testCase) {
 				// Ye is ignored.
 				"Zs":       Slice{{Z(time.Date(2006, 12, 1, 0, 0, 0, 0, time.UTC)), Q{11, 22}, &Q{33, 44}, Q{}, E{}}},
 				"E":        E{[]byte{0, 1, 2}, []byte{3, 4, 5}},
-				"P.D\\Q.B": P{"P/D", "Q-B"},
-			},
-		},
-		{decOnly, prepopulate(SXs{}), variation,
-			SXs{"B": true,
-				"life": 42,
-				"F":    6.6,
-				"C":    complex(42, 6.6),
-				"R":    '\u221E',
-				// Re is omitted.
-				"S": "Hello, there.",
-				"T": time.Date(2013, 10, 1, 7, 5, 34, 88, time.UTC),
-				"U": url.URL{Scheme: "http", Host: "example.org", Path: "/foo", Fragment: "bar"},
-				"A": Array{"x", "y", "z"},
-				"M": Map{"Foo": 7, "Bar": 8, "Qux": 9},
-				// Y is ignored.
-				// Ye is ignored.
-				"Zs":       Slice{{Z(time.Date(2006, 12, 1, 0, 0, 0, 0, time.UTC)), Q{11, 22}, &Q{33, 44}, Q{}, E{}}},
-				"E":        E{[]byte{0, 1, 2}, nil},
-				"Bytes2":   string([]byte{3, 4, 5}),
 				"P.D\\Q.B": P{"P/D", "Q-B"},
 			},
 		},
@@ -280,32 +239,6 @@ func testCases(dir direction) (cs []testCase) {
 					},
 				},
 				"E":        map[string]interface{}{"Bytes1": string([]byte{0, 1, 2}), "Bytes2": string([]byte{3, 4, 5})},
-				"P.D\\Q.B": map[string]interface{}{"A": "P/D", "B": "Q-B"},
-			},
-		},
-		{decOnly, SXs{}, variation,
-			SXs{"B": "true",
-				"life": "42",
-				"F":    "6.6",
-				"C":    "42+6.6i",
-				"R":    "8734",
-				// Re is omitted.
-				"S": "Hello, there.",
-				"T": "2013-10-01T07:05:34.000000088Z",
-				"U": "http://example.org/foo#bar",
-				"A": map[string]interface{}{"0": "x", "1": "y", "2": "z"},
-				"M": map[string]interface{}{"Foo": "7", "Bar": "8", "Qux": "9"},
-				// Y is ignored.
-				// Ye is ignored.
-				"Zs": map[string]interface{}{
-					"0": map[string]interface{}{
-						"Z":  "2006-12-01",
-						"Q":  "11_22",
-						"Qp": "33_44",
-					},
-				},
-				"E":        map[string]interface{}{"Bytes1": string([]byte{0, 1, 2})},
-				"Bytes2":   string([]byte{3, 4, 5}),
 				"P.D\\Q.B": map[string]interface{}{"A": "P/D", "B": "Q-B"},
 			},
 		},


### PR DESCRIPTION
As of go 1.17, the net/http and net/url packages no longer accept ';' as a valid separator. See https://golang.org/doc/go1.17#semicolons for more information.

In order to build this package with go 1.17 and keep it in Ubuntu, the test cases that use ';' as a separator should be removed.