### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [main, master]
 
+permissions:
+    contents: read
+
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ajg/form/security/code-scanning/2](https://github.com/ajg/form/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, just below the `on:` section and before `jobs:`.  
Best minimal fix without changing behavior is:

- `contents: read` (needed for `actions/checkout`)
  
No write permissions are required by the shown steps. Defining this at the workflow level applies to both `test` and `ci` jobs and satisfies least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
