### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+    contents: read
+
 on:
     push:
         branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/ajg/form/security/code-scanning/1](https://github.com/ajg/form/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token scopes.  
Best single fix without changing behavior: set:

- `contents: read`

This is the minimal starting point recommended by CodeQL and is sufficient for typical checkout/build/test workflows. Place it near the top of the workflow (after `name` and before `on`, or after `on`) so it applies to both `test` and `ci` jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
