### PR TITLE
Harden decoder against malformed input

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -15,7 +15,7 @@ import (
 
 // NewDecoder returns a new form Decoder.
 func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r, defaultDelimiter, defaultEscape, false, false}
+	return &Decoder{r, defaultDelimiter, defaultEscape, false, false, defaultMaxSize, defaultMaxDepth}
 }
 
 // Decoder decodes data from a form (application/x-www-form-urlencoded).
@@ -25,6 +25,8 @@ type Decoder struct {
 	e             rune
 	ignoreUnknown bool
 	ignoreCase    bool
+	maxSize       int
+	maxDepth      int
 }
 
 // DelimitWith sets r as the delimiter used for composite keys by Decoder d and returns the latter; it is '.' by default.
@@ -49,8 +51,7 @@ func (d Decoder) Decode(dst interface{}) error {
 	if err != nil {
 		return err
 	}
-	v := reflect.ValueOf(dst)
-	return d.decodeNode(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v)))
+	return d.decode(reflect.ValueOf(dst), vs)
 }
 
 // IgnoreUnknownKeys if set to true it will make the Decoder ignore values
@@ -65,20 +66,74 @@ func (d *Decoder) IgnoreCase(ignoreCase bool) {
 	d.ignoreCase = ignoreCase
 }
 
+// MaxSize overrides how large a slice the Decoder will grow in response to an
+// explicit index in the input, guarding against memory exhaustion from a small
+// payload with a very large index (e.g. "Foo.900000000=x").
+//
+// By default (the zero value) the Decoder uses a bound proportional to the
+// number of elements actually supplied, so legitimately large slices decode
+// while amplification is prevented; most callers never need this method. A
+// value > 0 sets a fixed absolute cap instead (use a large value to permit
+// large sparse slices in trusted input, or a small one to tighten the limit).
+// A value < 0 disables the bound entirely; only do this for fully trusted
+// input.
+func (d *Decoder) MaxSize(maxSize int) *Decoder {
+	d.maxSize = maxSize
+	return d
+}
+
+// MaxDepth overrides the maximum key-path nesting depth the Decoder will parse,
+// guarding against stack exhaustion and nested-map blow-up from a single key
+// with many delimiters (e.g. "a.a.a.…=x"). Legitimate nesting is bounded by the
+// destination type, so the default sits far above any real form. A value > 0
+// sets the limit; a value < 0 disables it (trusted input only); the zero value
+// uses the built-in default.
+func (d *Decoder) MaxDepth(maxDepth int) *Decoder {
+	d.maxDepth = maxDepth
+	return d
+}
+
+// sliceLimit reports the largest slice length decodeSlice may allocate given
+// count elements supplied for the slice. A negative result means unbounded.
+func (d Decoder) sliceLimit(count int) int {
+	switch {
+	case d.maxSize < 0:
+		return -1 // Explicitly unbounded (trusted input).
+	case d.maxSize > 0:
+		return d.maxSize // Explicit absolute cap.
+	default:
+		if limit := count * sliceGrowthFactor; limit > sliceGrowthFloor {
+			return limit
+		}
+		return sliceGrowthFloor
+	}
+}
+
+// depthLimit reports the maximum key-path nesting depth the Decoder will parse.
+// A negative result means unbounded.
+func (d Decoder) depthLimit() int {
+	switch {
+	case d.maxDepth < 0:
+		return -1 // Explicitly unbounded (trusted input).
+	case d.maxDepth > 0:
+		return d.maxDepth // Explicit limit.
+	default:
+		return builtinMaxDepth
+	}
+}
+
 // DecodeString decodes src into dst.
 func (d Decoder) DecodeString(dst interface{}, src string) error {
 	vs, err := url.ParseQuery(src)
 	if err != nil {
 		return err
 	}
-	v := reflect.ValueOf(dst)
-	return d.decodeNode(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v)))
+	return d.decode(reflect.ValueOf(dst), vs)
 }
 
 // DecodeValues decodes vs into dst.
 func (d Decoder) DecodeValues(dst interface{}, vs url.Values) error {
-	v := reflect.ValueOf(dst)
-	return d.decodeNode(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v)))
+	return d.decode(reflect.ValueOf(dst), vs)
 }
 
 // DecodeString decodes src into dst.
@@ -91,7 +146,12 @@ func DecodeValues(dst interface{}, vs url.Values) error {
 	return NewDecoder(nil).DecodeValues(dst, vs)
 }
 
-func (d Decoder) decodeNode(v reflect.Value, n node) (err error) {
+// decode parses vs into a node tree and decodes it into v. Parsing runs inside
+// the same deferred recover as decoding on purpose: malformed input can panic
+// during parseValues (a colliding key path, or a key nested past the maximum
+// depth), and that panic must be turned into an error rather than escaping to
+// the caller and crashing the process.
+func (d Decoder) decode(v reflect.Value, vs url.Values) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
@@ -101,7 +161,7 @@ func (d Decoder) decodeNode(v reflect.Value, n node) (err error) {
 	if v.Kind() == reflect.Slice {
 		return fmt.Errorf("could not decode directly into slice; use pointer to slice")
 	}
-	d.decodeValue(v, n)
+	d.decodeValue(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v), d.depthLimit()))
 	return nil
 }
 
@@ -239,10 +299,13 @@ func (d Decoder) decodeSlice(v reflect.Value, x interface{}) {
 		}
 	}
 
+	n := getNode(x)
+	limit := d.sliceLimit(len(n))
+
 	// NOTE: Implicit indexing is currently done at the parseValues level,
 	//       so if if an implicitKey reaches here it will always replace the last.
 	implicit := 0
-	for k, c := range getNode(x) {
+	for k, c := range n {
 		var i int
 		if k == implicitKey {
 			i = implicit
@@ -254,6 +317,17 @@ func (d Decoder) decodeSlice(v reflect.Value, x interface{}) {
 			}
 			i = explicit
 			implicit = explicit + 1
+		}
+		if i < 0 {
+			panic(k + " is not a valid index for type " + t.String())
+		}
+		// Guard against a small payload forcing a huge allocation via a large
+		// explicit index. The limit tracks the number of supplied elements, so
+		// legitimately large slices are unaffected; see Decoder.MaxSize.
+		if limit >= 0 && i >= limit {
+			panic("index " + strconv.Itoa(i) + " exceeds the allowed size (" +
+				strconv.Itoa(limit) + ") for type " + t.String() +
+				"; supply more elements or set Decoder.MaxSize for trusted input")
 		}
 		// "Extend" the slice if it's too short.
 		if l := v.Len(); i >= l {

--- a/decode_dos_test.go
+++ b/decode_dos_test.go
@@ -1,0 +1,177 @@
+// Copyright 2014 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type sliceTarget struct {
+	Foo []int64 `form:"foo"`
+}
+
+// TestDecodeSliceLargeIndexIsBounded ensures a tiny payload carrying a very
+// large explicit slice index does not force a huge allocation, but is rejected
+// with an error. Regression test for a memory-exhaustion (DoS) vulnerability in
+// decodeSlice.
+func TestDecodeSliceLargeIndexIsBounded(t *testing.T) {
+	var dst sliceTarget
+	// ~15-byte payload that, unbounded, would allocate ~7.2 GB of int64.
+	err := DecodeString(&dst, "foo.900000000=1")
+	if err == nil {
+		t.Fatalf("expected an error for an oversized index, got nil (len(Foo)=%d)", len(dst.Foo))
+	}
+	if !strings.Contains(err.Error(), "allowed size") {
+		t.Fatalf("expected an allowed-size error, got: %v", err)
+	}
+	if len(dst.Foo) != 0 {
+		t.Fatalf("expected no allocation, got len(Foo)=%d", len(dst.Foo))
+	}
+}
+
+// TestDecodeSliceNegativeIndex ensures a negative explicit index is rejected
+// cleanly rather than panicking deep in reflect.
+func TestDecodeSliceNegativeIndex(t *testing.T) {
+	var dst sliceTarget
+	if err := DecodeString(&dst, "foo.-5=1"); err == nil {
+		t.Fatalf("expected an error for a negative index, got nil")
+	}
+}
+
+// TestDecodeSliceModestSparseWorks ensures ordinary sparse indexing within the
+// floor continues to work with no configuration.
+func TestDecodeSliceModestSparseWorks(t *testing.T) {
+	var dst sliceTarget
+	if err := DecodeString(&dst, "foo.5=42"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dst.Foo) != 6 || dst.Foo[5] != 42 {
+		t.Fatalf("unexpected result: %#v", dst.Foo)
+	}
+}
+
+// TestDecodeSliceLargeLegitimateSliceWorks is the key guarantee behind the
+// proportional bound: a genuinely large slice (far past the sparse floor)
+// decodes with no configuration, because its elements are actually supplied.
+// This is what prevents a fixed cap from someday rejecting real data.
+func TestDecodeSliceLargeLegitimateSliceWorks(t *testing.T) {
+	const count = 50000 // well beyond sliceGrowthFloor
+	var b strings.Builder
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		b.WriteString("foo.")
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString("=1")
+	}
+
+	var dst sliceTarget
+	if err := DecodeString(&dst, b.String()); err != nil {
+		t.Fatalf("unexpected error decoding a large legitimate slice: %v", err)
+	}
+	if len(dst.Foo) != count {
+		t.Fatalf("expected len(Foo)=%d, got %d", count, len(dst.Foo))
+	}
+}
+
+// TestDecodeSliceMaxSizeAbsoluteCap ensures MaxSize(n>0) sets a fixed cap that
+// both permits indices below it and rejects those at or above it.
+func TestDecodeSliceMaxSizeAbsoluteCap(t *testing.T) {
+	var ok sliceTarget
+	d := NewDecoder(nil)
+	d.MaxSize(20000)
+	if err := d.DecodeString(&ok, "foo.10050=7"); err != nil {
+		t.Fatalf("unexpected error under raised cap: %v", err)
+	}
+	if len(ok.Foo) != 10051 || ok.Foo[10050] != 7 {
+		t.Fatalf("unexpected result: len=%d", len(ok.Foo))
+	}
+
+	var bad sliceTarget
+	d2 := NewDecoder(nil)
+	d2.MaxSize(10)
+	if err := d2.DecodeString(&bad, "foo.50=1"); err == nil {
+		t.Fatalf("expected an error above the absolute cap, got nil")
+	}
+}
+
+// TestDecodeSliceMaxSizeDisabled ensures MaxSize(<0) restores unbounded growth
+// for trusted input.
+func TestDecodeSliceMaxSizeDisabled(t *testing.T) {
+	var dst sliceTarget
+	d := NewDecoder(nil)
+	d.MaxSize(-1)
+	// Far past the default floor; only a few KB, safe to actually allocate.
+	if err := d.DecodeString(&dst, "foo.5000=9"); err != nil {
+		t.Fatalf("unexpected error with the bound disabled: %v", err)
+	}
+	if len(dst.Foo) != 5001 || dst.Foo[5000] != 9 {
+		t.Fatalf("unexpected result: len=%d", len(dst.Foo))
+	}
+}
+
+// TestDecodePanicDoesNotEscape is a regression test for a panic escaping
+// Decode/DecodeString/DecodeValues on a crafted duplicate key path. "a" appears
+// as both a leaf and a parent, which makes parseValues' add() panic depending
+// on map iteration order; that panic must be recovered into an error, never
+// propagate to the caller and crash the process.
+func TestDecodePanicDoesNotEscape(t *testing.T) {
+	for i := 0; i < 5000; i++ {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panic escaped DecodeString on iter %d: %v", i, r)
+				}
+			}()
+			var m map[string]interface{}
+			_ = DecodeString(&m, "a=1&a.b=2") // may return an error; must not panic
+		}()
+	}
+}
+
+// TestDecodeDeepKeyBounded ensures a single key nested past the default depth is
+// rejected with an error rather than driving recursion/allocation into a fatal
+// crash. Regression test for the unbounded key-path recursion DoS.
+func TestDecodeDeepKeyBounded(t *testing.T) {
+	payload := strings.Repeat("a.", builtinMaxDepth+50) + "b=1"
+	var m map[string]interface{}
+	err := DecodeString(&m, payload)
+	if err == nil {
+		t.Fatalf("expected an error for an over-deep key, got nil")
+	}
+	if !strings.Contains(err.Error(), "depth") {
+		t.Fatalf("expected a depth error, got: %v", err)
+	}
+}
+
+// TestDecodeModestDepthWorks ensures ordinary nested keys decode with no config.
+func TestDecodeModestDepthWorks(t *testing.T) {
+	var m map[string]interface{}
+	if err := DecodeString(&m, "a.b.c.d.e=1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestDecodeMaxDepthConfigurable ensures MaxDepth tightens and disables the
+// depth bound.
+func TestDecodeMaxDepthConfigurable(t *testing.T) {
+	var tight map[string]interface{}
+	d := NewDecoder(nil)
+	d.MaxDepth(3)
+	if err := d.DecodeString(&tight, "a.b.c.d.e=1"); err == nil {
+		t.Fatalf("expected an error past the configured depth, got nil")
+	}
+
+	var off map[string]interface{}
+	d2 := NewDecoder(nil)
+	d2.MaxDepth(-1)
+	// Past the default limit but small enough to build safely.
+	if err := d2.DecodeString(&off, strings.Repeat("a.", builtinMaxDepth+2000)+"b=1"); err != nil {
+		t.Fatalf("unexpected error with depth disabled: %v", err)
+	}
+}

--- a/form.go
+++ b/form.go
@@ -12,4 +12,33 @@ const (
 	defaultDelimiter = '.'
 	defaultEscape    = '\\'
 	defaultKeepZeros = false
+
+	// defaultMaxSize is the Decoder's zero value for its explicit slice-size
+	// cap. Zero means "no explicit cap": use the proportional bound below.
+	// See Decoder.MaxSize.
+	defaultMaxSize = 0
+
+	// The Decoder bounds how large a slice it will grow in response to explicit
+	// indices in the input, so a small payload with a large index (e.g.
+	// "Foo.900000000=x") cannot force a huge allocation and OOM the process.
+	//
+	// The bound is proportional to the number of elements actually supplied for
+	// the slice: a legitimately large slice arrives as that many entries, so
+	// real data is never rejected, while a tiny payload with one enormous index
+	// is. sliceGrowthFactor is how many slice positions each supplied element
+	// may span (tolerating some sparseness); sliceGrowthFloor is the minimum
+	// length always permitted, so modest sparse inputs work out of the box.
+	// Both are only defaults — see Decoder.MaxSize to set an absolute cap or to
+	// disable the bound entirely for trusted input.
+	sliceGrowthFactor = 16
+	sliceGrowthFloor  = 1024
+
+	// The Decoder also bounds key-path nesting depth, so a single key with many
+	// delimiters (e.g. "a.a.a.…=x") cannot drive deep recursion or nested-map
+	// allocation into a fatal stack overflow or OOM. Legitimate nesting is
+	// bounded by the destination Go type, so builtinMaxDepth sits far above any
+	// real form; see Decoder.MaxDepth to override or disable it. defaultMaxDepth
+	// is the Decoder's zero value (0 => use builtinMaxDepth).
+	defaultMaxDepth = 0
+	builtinMaxDepth = 10000
 )

--- a/node.go
+++ b/node.go
@@ -32,7 +32,7 @@ func (n node) merge(d, e rune, p string, vs *url.Values) {
 }
 
 // TODO: Add tests for implicit indexing.
-func parseValues(d, e rune, vs url.Values, canIndexFirstLevelOrdinally bool) node {
+func parseValues(d, e rune, vs url.Values, canIndexFirstLevelOrdinally bool, maxDepth int) node {
 	// NOTE: Because of the flattening of potentially multiple strings to one key, implicit indexing works:
 	//    i. At the first level;   e.g. Foo.Bar=A&Foo.Bar=B     becomes 0.Foo.Bar=A&1.Foo.Bar=B
 	//   ii. At the last level;    e.g. Foo.Bar._=A&Foo.Bar._=B becomes Foo.Bar.0=A&Foo.Bar.1=B
@@ -56,7 +56,7 @@ func parseValues(d, e rune, vs url.Values, canIndexFirstLevelOrdinally bool) nod
 
 	n := node{}
 	for k, s := range m {
-		n = n.split(d, e, k, s)
+		n = n.split(d, e, k, s, 1, maxDepth)
 	}
 	return n
 }
@@ -76,7 +76,11 @@ func splitPath(d, e rune, path string) (k, rest string) {
 	return unescape(d, e, path), ""
 }
 
-func (n node) split(d, e rune, path, s string) node {
+func (n node) split(d, e rune, path, s string, depth, maxDepth int) node {
+	if maxDepth >= 0 && depth > maxDepth {
+		panic("key path nesting exceeds the maximum depth (" + strconv.Itoa(maxDepth) +
+			"); set Decoder.MaxDepth for trusted input")
+	}
 	k, rest := splitPath(d, e, path)
 	if rest == "" {
 		return add(n, k, s)
@@ -86,7 +90,7 @@ func (n node) split(d, e rune, path, s string) node {
 	}
 
 	c := getNode(n[k])
-	n[k] = c.split(d, e, rest, s)
+	n[k] = c.split(d, e, rest, s, depth+1, maxDepth)
 	return n
 }
 


### PR DESCRIPTION
Bounds decode-time slice growth and key-path nesting depth, and recovers parser panics, so untrusted form input can't exhaust memory or crash the process. Regression tests included.