### PR TITLE
Enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds .github/dependabot.yml enabling weekly Dependabot updates for GitHub Actions and Go modules — keeps CI action versions current and flags vulnerable actions, complementing the workflow-permissions hardening.