### PR TITLE
Prevent stack overflow when encoding self-referential slices

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -151,6 +151,14 @@ func encodeValue(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interfa
 		}
 		return encodeStruct(v, z, o, seen)
 	case reflect.Slice:
+		if v.Len() > 0 {
+			ptr := v.Pointer()
+			if seen[ptr] {
+				panic("form: encoding a cycle via " + t.String())
+			}
+			seen[ptr] = true
+			defer delete(seen, ptr)
+		}
 		return encodeSlice(v, z, o, seen)
 	case reflect.Array:
 		return encodeArray(v, z, o, seen)

--- a/encode_cycle_test.go
+++ b/encode_cycle_test.go
@@ -1,0 +1,22 @@
+package form
+
+import "testing"
+
+func TestEncodeSelfReferentialSliceErrors(t *testing.T) {
+	s := make([]interface{}, 1)
+	s[0] = s
+	if _, err := EncodeToString(s); err == nil {
+		t.Fatal("expected a cycle error, got nil")
+	}
+}
+
+func TestEncodeNonCyclicSliceStillWorks(t *testing.T) {
+	if _, err := EncodeToString([]int{1, 2, 3}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	base := []int{1, 2, 3}
+	v := struct{ A, B []int }{A: base[:2], B: base[1:]}
+	if _, err := EncodeToString(v); err != nil {
+		t.Fatalf("unexpected error on shared-backing siblings: %v", err)
+	}
+}


### PR DESCRIPTION
Extends the encoder's existing pointer/map cycle detection to slices. A slice that references itself (e.g. via interface{}) previously recursed into a fatal stack overflow; it now returns an error, consistent with how pointer and map cycles are already handled. Adds regression tests, including a guard that ordinary and shared-backing slices still encode. Robustness fix on the non-attacker-facing encode path; targeted for v1.7.3.