### PR TITLE
Reject negative array indices and document decoder limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,28 @@ Custom:  foo.bar%2Fqux=XYZ
 
 (`%5C` and `%2F` represent `\` and `/`, respectively.)
 
+Limits
+------
+
+When decoding untrusted input, the `Decoder` bounds two dimensions to prevent
+resource-exhaustion denial of service (added in v1.7.2):
+
+ - **Slice size.** An explicit index such as `Foo.1000000=x` will not pre-allocate an
+   unbounded slice. By default the allowed length is proportional to the number of
+   elements actually supplied, so ordinary data is unaffected while a tiny payload
+   with a huge index is rejected. Override with `Decoder.MaxSize(n)`: `n > 0` sets a
+   fixed cap, `n < 0` disables the bound (trusted input only), and the zero value
+   keeps the proportional default.
+
+ - **Key-path depth.** A key with many delimiters such as `a.a.a.…=x` is rejected
+   past a maximum nesting depth (default 10000, far beyond any real form). Override
+   with `Decoder.MaxDepth(n)`: `n > 0` sets the limit, `n < 0` disables it (trusted
+   input only), and the zero value keeps the default.
+
+The package-level `DecodeString` and `DecodeValues` helpers use these safe defaults.
+If you decode large but trusted input and hit a limit, raise or disable it via the
+methods above.
+
 Related Work
 ------------
 

--- a/decode.go
+++ b/decode.go
@@ -279,7 +279,7 @@ func (d Decoder) decodeArray(v reflect.Value, x interface{}) {
 	t := v.Type()
 	for k, c := range getNode(x) {
 		i, err := strconv.Atoi(k)
-		if err != nil {
+		if err != nil || i < 0 {
 			panic(k + " is not a valid index for type " + t.String())
 		}
 		if l := v.Len(); i >= l {

--- a/decode_dos_test.go
+++ b/decode_dos_test.go
@@ -175,3 +175,14 @@ func TestDecodeMaxDepthConfigurable(t *testing.T) {
 		t.Fatalf("unexpected error with depth disabled: %v", err)
 	}
 }
+
+func TestDecodeArrayNegativeIndex(t *testing.T) {
+	var dst struct {
+		Foo [3]int `form:"foo"`
+	}
+	if err := DecodeString(&dst, "foo.-1=1"); err == nil {
+		t.Fatal("expected an error for a negative array index, got nil")
+	} else if !strings.Contains(err.Error(), "not a valid index") {
+		t.Fatalf("expected a clean index error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Two small robustness/quality items for v1.7.3, independent of the encoder-cycle PR.

- decodeArray now rejects negative indices (e.g. `foo.-1=x`) with the same clear "not a valid index" error the slice path already returns, instead of falling through to an internal `reflect: index out of range` panic caught by recover.
- README gains a "Limits" section documenting the MaxSize / MaxDepth decoder bounds introduced in v1.7.2 and how to configure them for trusted input.

Adds a regression test for the negative-index case.