### PR TITLE
Add typed errors (form.Error) with errors.As/Unwrap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,17 @@ The package-level `DecodeString` and `DecodeValues` helpers use these safe defau
 If you decode large but trusted input and hit a limit, raise or disable it via the
 methods above.
 
+Errors
+------
+
+Errors returned by the decoding and encoding functions are of type `*form.Error`,
+which records the operation that failed via `Op` (`form.OpDecode` or
+`form.OpEncode`) and, through `errors.Unwrap`, any underlying cause — such as an
+error from a `TextMarshaler`/`TextUnmarshaler` or a malformed-query error from the
+standard library. Detect and inspect them with `errors.As` and `errors.Is`. The
+message text returned by `Error` is unchanged from earlier versions, so code that
+matches on error strings continues to work.
+
 Related Work
 ------------
 

--- a/decode.go
+++ b/decode.go
@@ -154,12 +154,12 @@ func DecodeValues(dst interface{}, vs url.Values) error {
 func (d Decoder) decode(v reflect.Value, vs url.Values) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err = asError("decode", e)
+			err = asError(OpDecode, e)
 		}
 	}()
 
 	if v.Kind() == reflect.Slice {
-		return &Error{Op: "decode", msg: "could not decode directly into slice; use pointer to slice"}
+		return &Error{Op: OpDecode, msg: "could not decode directly into slice; use pointer to slice"}
 	}
 	d.decodeValue(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v), d.depthLimit()))
 	return nil

--- a/decode.go
+++ b/decode.go
@@ -154,12 +154,12 @@ func DecodeValues(dst interface{}, vs url.Values) error {
 func (d Decoder) decode(v reflect.Value, vs url.Values) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err = fmt.Errorf("%v", e)
+			err = asError("decode", e)
 		}
 	}()
 
 	if v.Kind() == reflect.Slice {
-		return fmt.Errorf("could not decode directly into slice; use pointer to slice")
+		return &Error{Op: "decode", msg: "could not decode directly into slice; use pointer to slice"}
 	}
 	d.decodeValue(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v), d.depthLimit()))
 	return nil

--- a/decode.go
+++ b/decode.go
@@ -45,11 +45,11 @@ func (d *Decoder) EscapeWith(r rune) *Decoder {
 func (d Decoder) Decode(dst interface{}) error {
 	bs, err := io.ReadAll(d.r)
 	if err != nil {
-		return err
+		return asError(OpDecode, err)
 	}
 	vs, err := url.ParseQuery(string(bs))
 	if err != nil {
-		return err
+		return asError(OpDecode, err)
 	}
 	return d.decode(reflect.ValueOf(dst), vs)
 }
@@ -126,7 +126,7 @@ func (d Decoder) depthLimit() int {
 func (d Decoder) DecodeString(dst interface{}, src string) error {
 	vs, err := url.ParseQuery(src)
 	if err != nil {
-		return err
+		return asError(OpDecode, err)
 	}
 	return d.decode(reflect.ValueOf(dst), vs)
 }

--- a/encode.go
+++ b/encode.go
@@ -115,7 +115,7 @@ func EncodeToValuesWith(dst interface{}, d rune, e rune, z bool) (url.Values, er
 func encodeToNode(v reflect.Value, z bool, o bool) (n node, err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err = fmt.Errorf("%v", e)
+			err = asError("encode", e)
 		}
 	}()
 	seen := make(map[uintptr]bool)

--- a/encode.go
+++ b/encode.go
@@ -115,7 +115,7 @@ func EncodeToValuesWith(dst interface{}, d rune, e rune, z bool) (url.Values, er
 func encodeToNode(v reflect.Value, z bool, o bool) (n node, err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err = asError("encode", e)
+			err = asError(OpEncode, e)
 		}
 	}()
 	seen := make(map[uintptr]bool)

--- a/encode.go
+++ b/encode.go
@@ -65,9 +65,9 @@ func (e Encoder) Encode(dst interface{}) error {
 	l, err := io.WriteString(e.w, s)
 	switch {
 	case err != nil:
-		return err
+		return asError(OpEncode, err)
 	case l != len(s):
-		return errors.New("could not write data completely")
+		return asError(OpEncode, errors.New("could not write data completely"))
 	}
 	return nil
 }

--- a/error.go
+++ b/error.go
@@ -6,6 +6,14 @@ package form
 
 import "fmt"
 
+// Op identifies the operation that produced an Error.
+type Op string
+
+const (
+	OpDecode Op = "decode"
+	OpEncode Op = "encode"
+)
+
 // Error is the error type returned by Decode and Encode operations for
 // malformed input or values that cannot be represented. Callers can use
 // errors.As to detect it and inspect Op, and errors.Unwrap (via Err) to reach
@@ -14,8 +22,8 @@ import "fmt"
 // The text returned by the Error method is identical to that of earlier
 // versions, so code matching on error strings is unaffected.
 type Error struct {
-	Op  string // the operation that failed: "decode" or "encode"
-	Err error  // the underlying cause, if any; nil when the message originates here
+	Op  Op    // the operation that failed
+	Err error // the underlying cause, if any; nil when the message originates here
 	msg string
 }
 
@@ -26,7 +34,7 @@ func (e *Error) Error() string { return e.msg }
 func (e *Error) Unwrap() error { return e.Err }
 
 // asError converts a recovered value into an *Error, preserving its message.
-func asError(op string, v interface{}) error {
+func asError(op Op, v interface{}) error {
 	switch t := v.(type) {
 	case *Error:
 		if t.Op == "" {

--- a/error.go
+++ b/error.go
@@ -1,0 +1,41 @@
+// Copyright 2014 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import "fmt"
+
+// Error is the error type returned by Decode and Encode operations for
+// malformed input or values that cannot be represented. Callers can use
+// errors.As to detect it and inspect Op, and errors.Unwrap (via Err) to reach
+// an underlying cause such as an error from a TextMarshaler or TextUnmarshaler.
+//
+// The text returned by the Error method is identical to that of earlier
+// versions, so code matching on error strings is unaffected.
+type Error struct {
+	Op  string // the operation that failed: "decode" or "encode"
+	Err error  // the underlying cause, if any; nil when the message originates here
+	msg string
+}
+
+// Error returns the error message.
+func (e *Error) Error() string { return e.msg }
+
+// Unwrap returns the underlying cause, enabling errors.Is and errors.As.
+func (e *Error) Unwrap() error { return e.Err }
+
+// asError converts a recovered value into an *Error, preserving its message.
+func asError(op string, v interface{}) error {
+	switch t := v.(type) {
+	case *Error:
+		if t.Op == "" {
+			t.Op = op
+		}
+		return t
+	case error:
+		return &Error{Op: op, Err: t, msg: t.Error()}
+	default:
+		return &Error{Op: op, msg: fmt.Sprintf("%v", t)}
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -16,7 +16,7 @@ func TestErrorIsTypedOnDecode(t *testing.T) {
 	if !errors.As(err, &fe) {
 		t.Fatalf("expected *form.Error, got %T", err)
 	}
-	if fe.Op != "decode" {
+	if fe.Op != OpDecode {
 		t.Errorf("Op = %q, want decode", fe.Op)
 	}
 	if !strings.Contains(err.Error(), "doesn't exist") {
@@ -34,7 +34,7 @@ func TestErrorIsTypedOnEncode(t *testing.T) {
 		if !errors.As(err, &fe) {
 			t.Fatalf("expected *form.Error, got %T", err)
 		}
-		if fe.Op != "encode" {
+		if fe.Op != OpEncode {
 			t.Errorf("Op = %q, want encode", fe.Op)
 		}
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -60,3 +60,44 @@ func TestErrorUnwrapReachesCause(t *testing.T) {
 		t.Fatalf("expected wrapped cause; got %#v", fe)
 	}
 }
+
+func TestErrorParseFailureIsTyped(t *testing.T) {
+	var dst struct{ A string }
+	err := DecodeString(&dst, "a=%zz") // url.ParseQuery fails
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var fe *Error
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *form.Error, got %T", err)
+	}
+	if fe.Op != OpDecode {
+		t.Errorf("Op = %q, want decode", fe.Op)
+	}
+	if fe.Err == nil {
+		t.Errorf("underlying parse error not preserved (Err is nil)")
+	}
+}
+
+type failWriter struct{}
+
+var errWriteFail = errors.New("write failed")
+
+func (failWriter) Write([]byte) (int, error) { return 0, errWriteFail }
+
+func TestErrorEncodeWriteFailureIsTyped(t *testing.T) {
+	err := NewEncoder(failWriter{}).Encode(struct{ A int }{1})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var fe *Error
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *form.Error, got %T", err)
+	}
+	if fe.Op != OpEncode {
+		t.Errorf("Op = %q, want encode", fe.Op)
+	}
+	if !errors.Is(err, errWriteFail) {
+		t.Errorf("underlying write error not reachable via errors.Is")
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,62 @@
+package form
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestErrorIsTypedOnDecode(t *testing.T) {
+	var dst struct{ A int }
+	err := DecodeString(&dst, "B=1")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var fe *Error
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *form.Error, got %T", err)
+	}
+	if fe.Op != "decode" {
+		t.Errorf("Op = %q, want decode", fe.Op)
+	}
+	if !strings.Contains(err.Error(), "doesn't exist") {
+		t.Errorf("message not preserved: %q", err.Error())
+	}
+}
+
+func TestErrorIsTypedOnEncode(t *testing.T) {
+	s := make([]interface{}, 1)
+	s[0] = s
+	if _, err := EncodeToString(s); err == nil {
+		t.Fatal("expected an error")
+	} else {
+		var fe *Error
+		if !errors.As(err, &fe) {
+			t.Fatalf("expected *form.Error, got %T", err)
+		}
+		if fe.Op != "encode" {
+			t.Errorf("Op = %q, want encode", fe.Op)
+		}
+	}
+}
+
+type textFailer struct{}
+
+var errTextFail = errors.New("text failer boom")
+
+func (*textFailer) UnmarshalText([]byte) error { return errTextFail }
+
+func TestErrorUnwrapReachesCause(t *testing.T) {
+	var dst struct{ F textFailer }
+	err := DecodeString(&dst, "F=x")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, errTextFail) {
+		t.Fatalf("errors.Is could not reach cause; err=%v", err)
+	}
+	var fe *Error
+	if !errors.As(err, &fe) || fe.Err != errTextFail {
+		t.Fatalf("expected wrapped cause; got %#v", fe)
+	}
+}

--- a/form.go
+++ b/form.go
@@ -3,6 +3,11 @@
 // license that can be found in the LICENSE file.
 
 // Package form implements encoding and decoding of application/x-www-form-urlencoded data.
+//
+// Errors returned by the Decode and Encode functions are of type *Error, which
+// records the operation (Op) that failed and, via Unwrap, any underlying cause
+// such as an error from a TextMarshaler or TextUnmarshaler. Use errors.As to
+// inspect them; the Error message text is unchanged from earlier versions.
 package form
 
 const (


### PR DESCRIPTION
Adds a typed error, form.Error, returned by decode and encode operations.

- form.Error carries Op ("decode" or "encode"), and when a panic wrapped an underlying error (e.g. from a TextMarshaler / TextUnmarshaler) that cause is reachable via errors.Unwrap / errors.As / errors.Is.
- The Error method returns the exact same text as before, so any code matching on error strings is unaffected. There is no signature change and no previously-exported error type or sentinel to conflict with, so the change is additive.
- Targeted for v1.8.

Includes tests for typed-error detection on both paths, preservation of the message text, and unwrapping to the underlying cause.