### PR TITLE
Add multipart/form-data decoding subpackage (form/multipart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,52 @@ standard library. Detect and inspect them with `errors.As` and `errors.Is`. The
 message text returned by `Error` is unchanged from earlier versions, so code that
 matches on error strings continues to work.
 
+File Uploads (multipart/form-data)
+----------------------------------
+
+HTML forms that contain file inputs submit `multipart/form-data` rather than
+`application/x-www-form-urlencoded`; the subpackage
+[form/multipart](./multipart) decodes such submissions into structs. Value
+fields follow the same rules as this package (field tags, nesting, custom
+delimiters, the limits above), while file parts are matched by name onto
+fields declared as any of `*multipart.FileHeader`, `[]*multipart.FileHeader`,
+`[]byte`, or `[][]byte`:
+
+```go
+import (
+	"mime/multipart"
+
+	formmp "github.com/ajg/form/multipart"
+)
+
+type Upload struct {
+	Name   string                  `form:"name"`
+	Avatar *multipart.FileHeader   `form:"avatar"` // Lazy: open/stream/close it yourself.
+	Docs   [][]byte                `form:"docs"`   // Eager: read into memory during decoding.
+}
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	var u Upload
+	if err := formmp.DecodeRequest(&u, r, 32<<20); err != nil { // Calls r.ParseMultipartForm.
+		// ...
+	}
+	// ...
+}
+```
+
+ - The `*multipart.FileHeader` forms hand over the standard library's own handle:
+   the caller `Open`s (and closes) the file and may stream it, so no size bound
+   is imposed by this package.
+ - The `[]byte` forms are read into memory during decoding, bounded by
+   `Decoder.MaxFileSize` (10 MiB per file by default) and `Decoder.MaxFiles`
+   (1000 per key by default), which follow the same zero/positive/negative
+   convention as the limits above.
+
+Like this package, decoding is strict by default: a value or file key that
+matches no destination field is an error. Browser submissions routinely carry
+extra fields (CSRF tokens, submit-button names); either model them or skip
+them with `formmp.NewDecoder().IgnoreUnknownKeys(true)`.
+
 Related Work
 ------------
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ fields declared as any of `*multipart.FileHeader`, `[]*multipart.FileHeader`,
 import (
 	"mime/multipart"
 
-	formdata "github.com/ajg/form/multipart"
+	fmp "github.com/ajg/form/multipart"
 )
 
 type Upload struct {
@@ -309,7 +309,7 @@ type Upload struct {
 
 func handle(w http.ResponseWriter, r *http.Request) {
 	var u Upload
-	if err := formdata.DecodeRequest(&u, r, 32<<20); err != nil { // Calls r.ParseMultipartForm.
+	if err := fmp.DecodeRequest(&u, r, 32<<20); err != nil { // Calls r.ParseMultipartForm.
 		// ...
 	}
 	// ...
@@ -327,7 +327,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 Like this package, decoding is strict by default: a value or file key that
 matches no destination field is an error. Browser submissions routinely carry
 extra fields (CSRF tokens, submit-button names); either model them or skip
-them with `formdata.NewDecoder().IgnoreUnknownKeys(true)`.
+them with `fmp.NewDecoder().IgnoreUnknownKeys(true)`.
 
 Related Work
 ------------

--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ Custom:  foo.bar%2Fqux=XYZ
 
 (`%5C` and `%2F` represent `\` and `/`, respectively.)
 
+Unknown Keys and Case
+---------------------
+
+Decoding is strict by default: a key that matches no field in the destination
+is an error. `Decoder.IgnoreUnknownKeys(true)` makes the decoder skip such
+values instead — the pragmatic choice for raw browser submissions, which
+routinely carry fields the destination doesn't model (CSRF tokens,
+submit-button names). Separately, `Decoder.IgnoreCase(true)` lets keys match
+fields even when their cases differ.
+
 Limits
 ------
 
@@ -288,7 +298,7 @@ fields declared as any of `*multipart.FileHeader`, `[]*multipart.FileHeader`,
 import (
 	"mime/multipart"
 
-	formmp "github.com/ajg/form/multipart"
+	formdata "github.com/ajg/form/multipart"
 )
 
 type Upload struct {
@@ -299,7 +309,7 @@ type Upload struct {
 
 func handle(w http.ResponseWriter, r *http.Request) {
 	var u Upload
-	if err := formmp.DecodeRequest(&u, r, 32<<20); err != nil { // Calls r.ParseMultipartForm.
+	if err := formdata.DecodeRequest(&u, r, 32<<20); err != nil { // Calls r.ParseMultipartForm.
 		// ...
 	}
 	// ...
@@ -317,7 +327,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 Like this package, decoding is strict by default: a value or file key that
 matches no destination field is an error. Browser submissions routinely carry
 extra fields (CSRF tokens, submit-button names); either model them or skip
-them with `formmp.NewDecoder().IgnoreUnknownKeys(true)`.
+them with `formdata.NewDecoder().IgnoreUnknownKeys(true)`.
 
 Related Work
 ------------

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 TODO
 ====
 
-  - Document IgnoreCase and IgnoreUnknownKeys in README.
   - An option to automatically treat all field names in `camelCase` or `underscore_case`.
   - Built-in support for the types in [`math/big`](http://golang.org/pkg/math/big/).
   - Built-in support for the types in [`image/color`](http://golang.org/pkg/image/color/).

--- a/multipart/multipart.go
+++ b/multipart/multipart.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package multipart decodes multipart/form-data — as submitted by HTML forms
+// containing file inputs — into Go structs, using github.com/ajg/form to
+// decode the value fields and mapping file parts onto struct fields by name.
+//
+// Value fields follow form's decoding rules (struct tags, nesting, custom
+// delimiters, and so on). File fields are matched by their top-level part
+// name — via the `form` or `json` struct tag, or the field name — and may be
+// declared as any of:
+//
+//	*multipart.FileHeader   // lazily read: the first file sent under the key
+//	[]*multipart.FileHeader // lazily read: every file sent under the key
+//	[]byte                  // eagerly read: contents of the first file
+//	[][]byte                // eagerly read: contents of every file
+//
+// The *multipart.FileHeader forms hand over mime/multipart's own handle: the
+// caller Opens (and Closes) the file itself and may stream it, so no bound is
+// imposed here. The []byte forms read the file into memory during decoding,
+// bounded by Decoder.MaxFileSize and Decoder.MaxFiles.
+//
+// Like form, decoding is strict by default: a value or file whose key matches
+// no destination field is an error. Real browser submissions often include
+// fields that aren't interesting to model (CSRF tokens, submit-button names);
+// either add matching struct fields or opt out of strictness with
+// NewDecoder().IgnoreUnknownKeys(true).
+package multipart
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+
+	"github.com/ajg/form"
+)
+
+const (
+	// The Decoder bounds how much file data it will read into memory for
+	// []byte and [][]byte fields, so a large upload cannot OOM the process
+	// merely by being decoded. builtinMaxFileSize is the per-file bound and
+	// builtinMaxFiles the per-field file-count bound used when the Decoder is
+	// not configured otherwise; see Decoder.MaxFileSize and Decoder.MaxFiles.
+	// These bounds do not apply to *multipart.FileHeader fields, which are
+	// read lazily by the caller.
+	builtinMaxFileSize = 10 << 20 // 10 MiB
+	builtinMaxFiles    = 1000
+)
+
+var (
+	fileHeaderPtr   = reflect.TypeOf((*multipart.FileHeader)(nil))
+	fileHeaderSlice = reflect.TypeOf([]*multipart.FileHeader(nil))
+	bytesValue      = reflect.TypeOf([]byte(nil))
+	bytesSlice      = reflect.TypeOf([][]byte(nil))
+)
+
+// Decoder decodes multipart/form-data into a struct. The zero configuration
+// (NewDecoder) is strict and bounded; see the methods for the knobs.
+type Decoder struct {
+	fd            *form.Decoder
+	ignoreUnknown bool
+	maxFileSize   int64
+	maxFiles      int
+}
+
+// NewDecoder returns a new multipart Decoder.
+func NewDecoder() *Decoder {
+	return &Decoder{fd: form.NewDecoder(nil)}
+}
+
+// DelimitWith sets r as the delimiter used for composite value keys and
+// returns the Decoder; it is '.' by default.
+func (d *Decoder) DelimitWith(r rune) *Decoder {
+	d.fd.DelimitWith(r)
+	return d
+}
+
+// EscapeWith sets r as the escape used for delimiters (and to escape itself)
+// in value keys and returns the Decoder; it is '\\' by default.
+func (d *Decoder) EscapeWith(r rune) *Decoder {
+	d.fd.EscapeWith(r)
+	return d
+}
+
+// IgnoreUnknownKeys, if set to true, makes the Decoder silently skip values
+// and files whose keys match no destination field, instead of returning an
+// error. It is false by default, matching form; setting it to true is the
+// pragmatic choice for raw browser submissions, which routinely carry fields
+// (CSRF tokens, submit-button names) that the destination doesn't model.
+func (d *Decoder) IgnoreUnknownKeys(ignoreUnknown bool) *Decoder {
+	d.ignoreUnknown = ignoreUnknown
+	d.fd.IgnoreUnknownKeys(ignoreUnknown)
+	return d
+}
+
+// IgnoreCase, if set to true, makes the Decoder try to set value fields even
+// if the case of the key does not match. It applies to value fields only;
+// file fields are always matched exactly.
+func (d *Decoder) IgnoreCase(ignoreCase bool) *Decoder {
+	d.fd.IgnoreCase(ignoreCase)
+	return d
+}
+
+// MaxSize corresponds to form's Decoder.MaxSize, bounding how large a slice
+// the value decoder will grow in response to an explicit index in the input.
+func (d *Decoder) MaxSize(maxSize int) *Decoder {
+	d.fd.MaxSize(maxSize)
+	return d
+}
+
+// MaxDepth corresponds to form's Decoder.MaxDepth, bounding the key-path
+// nesting depth the value decoder will parse.
+func (d *Decoder) MaxDepth(maxDepth int) *Decoder {
+	d.fd.MaxDepth(maxDepth)
+	return d
+}
+
+// MaxFileSize overrides how many bytes of a single file the Decoder will read
+// into memory for a []byte or [][]byte field; a larger file is an error. A
+// value > 0 sets the bound; a value < 0 disables it (trusted input only); the
+// zero value uses the built-in default of 10 MiB. It has no effect on
+// *multipart.FileHeader fields, which the caller reads lazily.
+func (d *Decoder) MaxFileSize(maxFileSize int64) *Decoder {
+	d.maxFileSize = maxFileSize
+	return d
+}
+
+// MaxFiles overrides how many files the Decoder will accept under a single
+// key for a slice-valued file field; more is an error. A value > 0 sets the
+// bound; a value < 0 disables it; the zero value uses the built-in default of
+// 1000.
+func (d *Decoder) MaxFiles(maxFiles int) *Decoder {
+	d.maxFiles = maxFiles
+	return d
+}
+
+// fileSizeLimit reports the largest single file the Decoder will read into
+// memory. A negative result means unbounded.
+func (d *Decoder) fileSizeLimit() int64 {
+	switch {
+	case d.maxFileSize < 0:
+		return -1 // Explicitly unbounded (trusted input).
+	case d.maxFileSize > 0:
+		return d.maxFileSize // Explicit bound.
+	default:
+		return builtinMaxFileSize
+	}
+}
+
+// filesLimit reports the largest number of files the Decoder will accept for
+// a slice-valued file field. A negative result means unbounded.
+func (d *Decoder) filesLimit() int {
+	switch {
+	case d.maxFiles < 0:
+		return -1 // Explicitly unbounded (trusted input).
+	case d.maxFiles > 0:
+		return d.maxFiles // Explicit bound.
+	default:
+		return builtinMaxFiles
+	}
+}
+
+// DecodeForm decodes the already-parsed multipart form mf into dst, which
+// must be a non-nil pointer to a struct.
+func (d *Decoder) DecodeForm(dst interface{}, mf *multipart.Form) error {
+	if mf == nil {
+		return errors.New("form/multipart: nil *multipart.Form")
+	}
+	v := reflect.ValueOf(dst)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return errors.New("form/multipart: dst must be a non-nil pointer to a struct")
+	}
+	if v.Elem().Kind() != reflect.Struct {
+		return errors.New("form/multipart: dst must point to a struct")
+	}
+	if len(mf.Value) > 0 {
+		if err := d.fd.DecodeValues(dst, url.Values(mf.Value)); err != nil {
+			return err
+		}
+	}
+	return d.setFiles(v.Elem(), mf.File)
+}
+
+// DecodeRequest parses r's body as multipart/form-data — via
+// (*http.Request).ParseMultipartForm, buffering up to maxMemory bytes of file
+// data in memory and the remainder in temporary files — and decodes the
+// result into dst, which must be a non-nil pointer to a struct.
+func (d *Decoder) DecodeRequest(dst interface{}, r *http.Request, maxMemory int64) error {
+	if err := r.ParseMultipartForm(maxMemory); err != nil {
+		return err
+	}
+	return d.DecodeForm(dst, r.MultipartForm)
+}
+
+// DecodeForm decodes the already-parsed multipart form mf into dst using a
+// default (strict, bounded) Decoder.
+func DecodeForm(dst interface{}, mf *multipart.Form) error {
+	return NewDecoder().DecodeForm(dst, mf)
+}
+
+// DecodeRequest parses r's body as multipart/form-data and decodes the result
+// into dst using a default (strict, bounded) Decoder.
+func DecodeRequest(dst interface{}, r *http.Request, maxMemory int64) error {
+	return NewDecoder().DecodeRequest(dst, r, maxMemory)
+}
+
+// setFiles maps each file part onto the matching struct field of v.
+func (d *Decoder) setFiles(v reflect.Value, files map[string][]*multipart.FileHeader) error {
+	fields := fieldsByName(v)
+	for name, fhs := range files {
+		if len(fhs) == 0 {
+			continue
+		}
+		fv, ok := fields[name]
+		if !ok {
+			if d.ignoreUnknown {
+				continue
+			}
+			return fmt.Errorf("form/multipart: unknown file key %q; set Decoder.IgnoreUnknownKeys(true) to skip unmodeled fields", name)
+		}
+		switch fv.Type() {
+		case fileHeaderPtr:
+			fv.Set(reflect.ValueOf(fhs[0]))
+		case fileHeaderSlice:
+			if limit := d.filesLimit(); limit >= 0 && len(fhs) > limit {
+				return tooManyFiles(name, len(fhs), limit)
+			}
+			fv.Set(reflect.ValueOf(fhs))
+		case bytesValue:
+			bs, err := d.readFile(fhs[0])
+			if err != nil {
+				return err
+			}
+			fv.Set(reflect.ValueOf(bs))
+		case bytesSlice:
+			if limit := d.filesLimit(); limit >= 0 && len(fhs) > limit {
+				return tooManyFiles(name, len(fhs), limit)
+			}
+			bss := make([][]byte, 0, len(fhs))
+			for _, fh := range fhs {
+				bs, err := d.readFile(fh)
+				if err != nil {
+					return err
+				}
+				bss = append(bss, bs)
+			}
+			fv.Set(reflect.ValueOf(bss))
+		default:
+			if d.ignoreUnknown {
+				continue
+			}
+			return fmt.Errorf("form/multipart: cannot decode file %q into field of type %v", name, fv.Type())
+		}
+	}
+	return nil
+}
+
+// readFile reads a single file part fully into memory, bounded by
+// Decoder.MaxFileSize.
+func (d *Decoder) readFile(fh *multipart.FileHeader) ([]byte, error) {
+	limit := d.fileSizeLimit()
+	if limit >= 0 && fh.Size > limit {
+		return nil, tooLarge(fh, limit)
+	}
+	f, err := fh.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	r := io.Reader(f)
+	if limit >= 0 {
+		// Trust the actual bytes, not just the reported Size.
+		r = io.LimitReader(f, limit+1)
+	}
+	bs, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	if limit >= 0 && int64(len(bs)) > limit {
+		return nil, tooLarge(fh, limit)
+	}
+	return bs, nil
+}
+
+func tooLarge(fh *multipart.FileHeader, limit int64) error {
+	return fmt.Errorf("form/multipart: file %q exceeds the maximum size (%d bytes) read into memory; see Decoder.MaxFileSize, or use a *multipart.FileHeader field to stream it", fh.Filename, limit)
+}
+
+func tooManyFiles(name string, n, limit int) error {
+	return fmt.Errorf("form/multipart: key %q carries %d files, exceeding the maximum (%d); see Decoder.MaxFiles", name, n, limit)
+}
+
+// fieldsByName indexes the settable, exported fields of struct value v by
+// their decoded name (per fieldName).
+func fieldsByName(v reflect.Value) map[string]reflect.Value {
+	fields := map[string]reflect.Value{}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		if sf.PkgPath != "" {
+			continue // Unexported.
+		}
+		fv := v.Field(i)
+		if !fv.CanSet() {
+			continue
+		}
+		name := fieldName(sf)
+		if name == "-" {
+			continue
+		}
+		fields[name] = fv
+	}
+	return fields
+}
+
+// fieldName reports the key under which struct field sf is decoded: the name
+// in its `form` tag, else its `json` tag, else the field's own name.
+func fieldName(sf reflect.StructField) string {
+	for _, key := range [2]string{"form", "json"} {
+		if tag := sf.Tag.Get(key); tag != "" {
+			if name := strings.SplitN(tag, ",", 2)[0]; name != "" {
+				return name
+			}
+		}
+	}
+	return sf.Name
+}

--- a/multipart/multipart_test.go
+++ b/multipart/multipart_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package multipart
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type target struct {
+	Name   string                  `form:"name"`
+	Age    int                     `form:"age"`
+	Avatar *multipart.FileHeader   `form:"avatar"`
+	Docs   []*multipart.FileHeader `form:"docs"`
+}
+
+type eagerTarget struct {
+	Name   string   `form:"name"`
+	Avatar []byte   `form:"avatar"`
+	Docs   [][]byte `form:"docs"`
+}
+
+type field struct {
+	name, value string
+}
+
+type file struct {
+	key, name, content string
+}
+
+// writeMultipart builds a multipart/form-data body from vs and fs, returning
+// the body and its boundary.
+func writeMultipart(t *testing.T, vs []field, fs []file) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	for _, v := range vs {
+		if err := w.WriteField(v.name, v.value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, f := range fs {
+		fw, err := w.CreateFormFile(f.key, f.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := fw.Write([]byte(f.content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return body, w.Boundary()
+}
+
+// parseForm turns a built body back into a *multipart.Form.
+func parseForm(t *testing.T, body *bytes.Buffer, boundary string) *multipart.Form {
+	t.Helper()
+	mf, err := multipart.NewReader(body, boundary).ReadForm(1 << 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mf
+}
+
+func defaultBody(t *testing.T) (*bytes.Buffer, string) {
+	t.Helper()
+	return writeMultipart(t,
+		[]field{{"name", "Alice"}, {"age", "30"}},
+		[]file{
+			{"avatar", "avatar.png", "fake png bytes"},
+			{"docs", "a.txt", "first doc"},
+			{"docs", "b.txt", "second doc"},
+		},
+	)
+}
+
+func TestDecodeForm(t *testing.T) {
+	body, boundary := defaultBody(t)
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst target
+	if err := DecodeForm(&dst, mf); err != nil {
+		t.Fatal(err)
+	}
+	if dst.Name != "Alice" || dst.Age != 30 {
+		t.Errorf("values: got (%q, %d), want (\"Alice\", 30)", dst.Name, dst.Age)
+	}
+	if dst.Avatar == nil || dst.Avatar.Filename != "avatar.png" {
+		t.Errorf("avatar: got %+v, want avatar.png", dst.Avatar)
+	}
+	if len(dst.Docs) != 2 || dst.Docs[0].Filename != "a.txt" || dst.Docs[1].Filename != "b.txt" {
+		t.Errorf("docs: got %+v, want [a.txt b.txt]", dst.Docs)
+	}
+}
+
+func TestDecodeRequest(t *testing.T) {
+	body, boundary := defaultBody(t)
+	r := httptest.NewRequest("POST", "/upload", body)
+	r.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+
+	var dst target
+	if err := DecodeRequest(&dst, r, 1<<20); err != nil {
+		t.Fatal(err)
+	}
+	defer r.MultipartForm.RemoveAll()
+	if dst.Name != "Alice" || dst.Age != 30 || dst.Avatar == nil || len(dst.Docs) != 2 {
+		t.Errorf("got %+v", dst)
+	}
+}
+
+func TestDecodeFormEager(t *testing.T) {
+	body, boundary := defaultBody(t)
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst eagerTarget
+	if err := NewDecoder().IgnoreUnknownKeys(true).DecodeForm(&dst, mf); err != nil {
+		t.Fatal(err)
+	}
+	if string(dst.Avatar) != "fake png bytes" {
+		t.Errorf("avatar: got %q", dst.Avatar)
+	}
+	if len(dst.Docs) != 2 || string(dst.Docs[0]) != "first doc" || string(dst.Docs[1]) != "second doc" {
+		t.Errorf("docs: got %q", dst.Docs)
+	}
+}
+
+func TestUnknownValueKey(t *testing.T) {
+	body, boundary := writeMultipart(t,
+		[]field{{"name", "Alice"}, {"age", "30"}, {"csrf_token", "abc123"}},
+		nil,
+	)
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst target
+	if err := DecodeForm(&dst, mf); err == nil {
+		t.Error("strict: expected error for unknown value key, got nil")
+	}
+	dst = target{}
+	if err := NewDecoder().IgnoreUnknownKeys(true).DecodeForm(&dst, mf); err != nil {
+		t.Errorf("lenient: unexpected error: %v", err)
+	} else if dst.Name != "Alice" {
+		t.Errorf("lenient: got %+v", dst)
+	}
+}
+
+func TestUnknownFileKey(t *testing.T) {
+	body, boundary := writeMultipart(t,
+		[]field{{"name", "Alice"}, {"age", "30"}},
+		[]file{{"surprise", "s.txt", "unexpected"}},
+	)
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst target
+	err := DecodeForm(&dst, mf)
+	if err == nil {
+		t.Error("strict: expected error for unknown file key, got nil")
+	} else if !strings.Contains(err.Error(), `"surprise"`) {
+		t.Errorf("strict: error should name the key: %v", err)
+	}
+	dst = target{}
+	if err := NewDecoder().IgnoreUnknownKeys(true).DecodeForm(&dst, mf); err != nil {
+		t.Errorf("lenient: unexpected error: %v", err)
+	}
+}
+
+func TestUnsupportedFileField(t *testing.T) {
+	body, boundary := writeMultipart(t, nil,
+		[]file{{"name", "n.txt", "a file aimed at a string field"}},
+	)
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst target
+	if err := DecodeForm(&dst, mf); err == nil {
+		t.Error("strict: expected error for file into string field, got nil")
+	}
+	dst = target{}
+	if err := NewDecoder().IgnoreUnknownKeys(true).DecodeForm(&dst, mf); err != nil {
+		t.Errorf("lenient: unexpected error: %v", err)
+	} else if dst.Name != "" {
+		t.Errorf("lenient: string field should be untouched, got %q", dst.Name)
+	}
+}
+
+func TestMaxFileSize(t *testing.T) {
+	body, boundary := writeMultipart(t, nil,
+		[]file{{"avatar", "big.png", strings.Repeat("x", 100)}},
+	)
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst eagerTarget
+	if err := NewDecoder().MaxFileSize(99).DecodeForm(&dst, mf); err == nil {
+		t.Error("expected error for file over MaxFileSize, got nil")
+	}
+	dst = eagerTarget{}
+	if err := NewDecoder().MaxFileSize(100).DecodeForm(&dst, mf); err != nil {
+		t.Errorf("file at exactly MaxFileSize should decode: %v", err)
+	} else if len(dst.Avatar) != 100 {
+		t.Errorf("got %d bytes, want 100", len(dst.Avatar))
+	}
+
+	// The bound must not apply to lazily-read *multipart.FileHeader fields.
+	body, boundary = writeMultipart(t, nil,
+		[]file{{"avatar", "big.png", strings.Repeat("x", 100)}},
+	)
+	mf = parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+	var lazy target
+	if err := NewDecoder().MaxFileSize(1).DecodeForm(&lazy, mf); err != nil {
+		t.Errorf("FileHeader field should ignore MaxFileSize: %v", err)
+	}
+}
+
+func TestMaxFiles(t *testing.T) {
+	body, boundary := writeMultipart(t, nil, []file{
+		{"docs", "a.txt", "a"},
+		{"docs", "b.txt", "b"},
+		{"docs", "c.txt", "c"},
+	})
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst target
+	if err := NewDecoder().MaxFiles(2).DecodeForm(&dst, mf); err == nil {
+		t.Error("expected error for more files than MaxFiles, got nil")
+	}
+	dst = target{}
+	if err := NewDecoder().MaxFiles(3).DecodeForm(&dst, mf); err != nil {
+		t.Errorf("exactly MaxFiles files should decode: %v", err)
+	} else if len(dst.Docs) != 3 {
+		t.Errorf("got %d docs, want 3", len(dst.Docs))
+	}
+}
+
+func TestDecodeFormErrors(t *testing.T) {
+	if err := DecodeForm(&target{}, nil); err == nil {
+		t.Error("nil form: expected error")
+	}
+	mf := &multipart.Form{}
+	if err := DecodeForm(target{}, mf); err == nil {
+		t.Error("non-pointer dst: expected error")
+	}
+	if err := DecodeForm((*target)(nil), mf); err == nil {
+		t.Error("nil pointer dst: expected error")
+	}
+	s := "nope"
+	if err := DecodeForm(&s, mf); err == nil {
+		t.Error("pointer to non-struct dst: expected error")
+	}
+}


### PR DESCRIPTION
Adds `github.com/ajg/form/multipart`: decodes `multipart/form-data` (HTML forms with file inputs) into structs, delegating value fields to `form` and mapping file parts onto fields by name.

**File field targets**
- `*multipart.FileHeader` / `[]*multipart.FileHeader` — lazy; caller opens/streams/closes, unbounded here.
- `[]byte` / `[][]byte` — eager; read into memory during decode, bounded by `MaxFileSize` (default 10 MiB, enforced against actual bytes via `LimitReader`, not just the reported `Size`) and `MaxFiles` (default 1000). Both follow form's 0=default / >0=explicit / <0=unbounded convention.

**API**
- Free functions `DecodeForm(dst, *multipart.Form)` and `DecodeRequest(dst, *http.Request, maxMemory)` for zero-config use.
- `NewDecoder()` with chainable configuration; `DelimitWith`, `EscapeWith`, `IgnoreCase`, `MaxSize`, `MaxDepth`, and `IgnoreUnknownKeys` pass through to the underlying `form.Decoder`, so value decoding behaves identically to form (including `*form.Error` typed errors from #47).

**Strictness**
Strict by default, matching form: an unmodeled value *or file* key is an error (form already errors on unmodeled value keys in urlencoded bodies carrying the same CSRF/submit-button noise, so this is no new friction). The error message points to `IgnoreUnknownKeys(true)` as the browser-noise escape hatch. Strict mode also catches file parts aimed at fields of unsupported types, which lenient matching would silently drop.

Nine tests cover both lazy and eager targets, strict/lenient behavior for value and file keys, limit boundaries (at-limit passes, one-over fails), that `MaxFileSize` does not constrain lazy `FileHeader` fields, and dst validation.