### PR TITLE
Extend the CI Go matrix through 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                go-pkg: ['go_1_17', 'go_1_18', 'go_1_19', 'go_1_20', 'go_1_21', 'go_1_22']
+                go-pkg: ['go_1_17', 'go_1_18', 'go_1_19', 'go_1_20', 'go_1_21', 'go_1_22', 'go_1_23', 'go_1_24', 'go_1_25', 'go_1_26']
         steps:
             - uses: actions/checkout@v7
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,20 @@
 { goPackage ? "go" }:
 
 let
-  # Current nixpkgs (has go_1_21, go_1_22)
-  pkgsCurrent = import (fetchTarball
+  # Current nixpkgs, mid-2026 - has go (1.26.x) and go_1_25
+  pkgsGo2526 = import (fetchTarball
+    "https://github.com/NixOS/nixpkgs/archive/3d46470bb3030020f7e1361f33514854f5bfa86d.tar.gz") { };
+
+  # nixpkgs snapshot with go_1_24 (1.24.13)
+  pkgsGo24 = import (fetchTarball
+    "https://github.com/NixOS/nixpkgs/archive/80d901ec0377e19ac3f7bb8c035201e2e098cc97.tar.gz") { };
+
+  # nixpkgs snapshot with go_1_23 (1.23.12)
+  pkgsGo23 = import (fetchTarball
+    "https://github.com/NixOS/nixpkgs/archive/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1.tar.gz") { };
+
+  # nixpkgs snapshot with go_1_21, go_1_22
+  pkgsGo2122 = import (fetchTarball
     "https://github.com/NixOS/nixpkgs/archive/8c5066250910.tar.gz") { };
 
   # nixpkgs 23.05 - has go_1_18, go_1_19, go_1_20
@@ -15,16 +27,20 @@ let
 
   # Map Go packages to their source
   goFromPkgs = {
-    go = pkgsCurrent.go;
+    go = pkgsGo2526.go;
     go_1_17 = pkgs2205.go_1_17;
     go_1_18 = pkgs2305.go_1_18;
     go_1_19 = pkgs2305.go_1_19;
     go_1_20 = pkgs2305.go_1_20;
-    go_1_21 = pkgsCurrent.go_1_21;
-    go_1_22 = pkgsCurrent.go_1_22;
+    go_1_21 = pkgsGo2122.go_1_21;
+    go_1_22 = pkgsGo2122.go_1_22;
+    go_1_23 = pkgsGo23.go_1_23;
+    go_1_24 = pkgsGo24.go_1_24;
+    go_1_25 = pkgsGo2526.go_1_25;
+    go_1_26 = pkgsGo2526.go;
   };
 
-in pkgsCurrent.mkShell {
+in pkgsGo2526.mkShell {
   buildInputs = [
     goFromPkgs.${goPackage}
   ];


### PR DESCRIPTION
Adds Go 1.23, 1.24, 1.25, and 1.26 to the CI test matrix (1.26 is the current release; upstream supports 1.25 and 1.26). The README promises Go 1.17+, so the matrix now covers the full supported span: ten versions.

nixpkgs drops old Go attributes as it rolls forward, so no single snapshot provides all ten; `shell.nix` gains three pinned snapshots alongside the existing ones — one current pin providing both `go` (1.26.x) and `go_1_25`, plus pins for `go_1_24` (1.24.13) and `go_1_23` (1.23.12) — and the interactive default `go` now points at 1.26 instead of the stale 1.22-era pin. The existing cache key already incorporates the matrix entry and `hashFiles('shell.nix')`, so each new rung caches independently after its first run.

No code changes; the pins are validated by this PR's own CI run.