### PR TITLE
Test and document math/big support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ A composite value is one that can contain other values. Values of the following 
 While encouraged, it is not necessary to define a type (e.g. a `struct`) in order to use `form`, since it is able to encode and decode untyped data generically using the following rules:
 
  - Simple values will be treated as a `string`.
+ - Because `application/x-www-form-urlencoded` carries no type information, no
+   numeric (or other) interpretation is attempted: simple values are preserved
+   as strings exactly as sent, so numerals of any magnitude — including those
+   exceeding Go's primitive types — survive losslessly, and the caller decides
+   how, and at what precision, to parse them.
  - Composite values will be treated as a `map[string]interface{}`, itself able to contain nested values (both simple and composite) ad infinitum.
  - However, if there is a value (of any supported type) already present in a map for a given key, then it will be used when possible, rather than being replaced with a generic value as specified above; this makes it possible to handle partially typed, dynamic or schema-less values.
 
@@ -195,6 +200,13 @@ func (b *Binary) UnmarshalText(text []byte) error {
 ```
 
 Now any value with type `Binary` will automatically be encoded using the [URL](http://golang.org/pkg/encoding/base64/#URLEncoding) variant of base64. It is left as an exercise to the reader to improve upon this scheme by eliminating the need for padding (which, besides being superfluous, uses `=`, a character that will end up percent-escaped.)
+
+Standard-library types that implement these interfaces work out of the box.
+Notably, that includes [`math/big`](http://golang.org/pkg/math/big/)'s `Int`,
+`Float` and `Rat`, which therefore encode and decode losslessly at arbitrary
+precision — the natural destinations for numeric values that may exceed Go's
+primitive types, which fail loudly rather than truncate silently when a value
+is out of range.
 
 Keys
 ----

--- a/README.md
+++ b/README.md
@@ -202,11 +202,13 @@ func (b *Binary) UnmarshalText(text []byte) error {
 Now any value with type `Binary` will automatically be encoded using the [URL](http://golang.org/pkg/encoding/base64/#URLEncoding) variant of base64. It is left as an exercise to the reader to improve upon this scheme by eliminating the need for padding (which, besides being superfluous, uses `=`, a character that will end up percent-escaped.)
 
 Standard-library types that implement these interfaces work out of the box.
-Notably, that includes [`math/big`](http://golang.org/pkg/math/big/)'s `Int`,
-`Float` and `Rat`, which therefore encode and decode losslessly at arbitrary
-precision — the natural destinations for numeric values that may exceed Go's
-primitive types, which fail loudly rather than truncate silently when a value
-is out of range.
+Notably, that includes [`math/big`](http://golang.org/pkg/math/big/): `Int`
+and `Rat` encode and decode losslessly at arbitrary precision, and `Float` at
+its destination's precision — a 64-bit mantissa by default (already wider
+than `float64`), or any precision pre-set on the destination value with
+`SetPrec` before decoding. These are the natural destinations for numeric
+values too large for Go's primitive types; decoding an out-of-range value
+into a primitive fails loudly rather than truncating silently.
 
 Keys
 ----

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,5 @@ TODO
 
   - Document IgnoreCase and IgnoreUnknownKeys in README.
   - An option to automatically treat all field names in `camelCase` or `underscore_case`.
-  - Built-in support for the types in [`math/big`](http://golang.org/pkg/math/big/).
   - Built-in support for the types in [`image/color`](http://golang.org/pkg/image/color/).
   - Improve encoding/decoding by reading/writing directly from/to the `io.Reader`/`io.Writer` when possible, rather than going through an intermediate representation (i.e. `node`) which requires more memory.

--- a/big_test.go
+++ b/big_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// The math/big types implement encoding.TextMarshaler and
+// encoding.TextUnmarshaler, so they encode and decode out of the box at
+// arbitrary precision; these tests pin that behavior.
+
+type bigValues struct {
+	I *big.Int   `form:"i"`
+	V big.Int    `form:"v"`
+	F *big.Float `form:"f"`
+	R *big.Rat   `form:"r"`
+}
+
+const oversized = "123456789012345678901234567890" // > 2^64
+
+func TestBigDecode(t *testing.T) {
+	var dst bigValues
+	if err := DecodeString(&dst, "i="+oversized+"&v=42&f=3.25&r=22/7"); err != nil {
+		t.Fatal(err)
+	}
+	if dst.I == nil || dst.I.String() != oversized {
+		t.Errorf("*big.Int: got %v, want %s", dst.I, oversized)
+	}
+	if dst.V.String() != "42" {
+		t.Errorf("big.Int value field: got %v, want 42", &dst.V)
+	}
+	if dst.F == nil || dst.F.String() != "3.25" {
+		t.Errorf("*big.Float: got %v, want 3.25", dst.F)
+	}
+	if dst.R == nil || dst.R.String() != "22/7" {
+		t.Errorf("*big.Rat: got %v, want 22/7", dst.R)
+	}
+}
+
+func TestBigEncode(t *testing.T) {
+	i, ok := new(big.Int).SetString(oversized, 10)
+	if !ok {
+		t.Fatal("SetString failed")
+	}
+	src := bigValues{I: i, F: big.NewFloat(3.25), R: big.NewRat(22, 7)}
+	src.V.SetInt64(42)
+	s, err := EncodeToString(&src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"i=" + oversized, "v=42", "f=3.25", "r=22%2F7"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("encoded form %q lacks %q", s, want)
+		}
+	}
+}
+
+// Untyped decoding performs no numeric interpretation: every simple value is
+// preserved as a string, so numerals of any magnitude survive losslessly and
+// the caller chooses how (and at what precision) to parse them.
+func TestUntypedNumeralsRemainStrings(t *testing.T) {
+	dst := map[string]interface{}{}
+	if err := DecodeString(&dst, "a=42&b="+oversized+"&c=3.14&d=1e400&e=007"); err != nil {
+		t.Fatal(err)
+	}
+	for k, v := range dst {
+		if _, ok := v.(string); !ok {
+			t.Errorf("untyped value %q: got %T, want string", k, v)
+		}
+	}
+	if dst["b"] != oversized {
+		t.Errorf("oversized numeral not preserved: got %v", dst["b"])
+	}
+	if dst["e"] != "007" {
+		t.Errorf("leading zeros not preserved: got %v", dst["e"])
+	}
+}
+
+// Values that exceed a primitive destination's range fail loudly instead of
+// being silently truncated; math/big destinations are the remedy.
+func TestPrimitiveOverflowErrors(t *testing.T) {
+	var i struct {
+		N int64 `form:"n"`
+	}
+	if err := DecodeString(&i, "n="+oversized); err == nil {
+		t.Error("expected error decoding oversized integer into int64")
+	}
+	var f struct {
+		X float64 `form:"x"`
+	}
+	if err := DecodeString(&f, "x=1e400"); err == nil {
+		t.Error("expected error decoding out-of-range float into float64")
+	}
+}

--- a/big_test.go
+++ b/big_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 // The math/big types implement encoding.TextMarshaler and
-// encoding.TextUnmarshaler, so they encode and decode out of the box at
-// arbitrary precision; these tests pin that behavior.
+// encoding.TextUnmarshaler, so they encode and decode out of the box — Int
+// and Rat at arbitrary precision, Float at the destination's precision
+// (a 64-bit mantissa unless pre-set); these tests pin that behavior.
 
 type bigValues struct {
 	I *big.Int   `form:"i"`
@@ -25,7 +26,7 @@ const oversized = "123456789012345678901234567890" // > 2^64
 
 func TestBigDecode(t *testing.T) {
 	var dst bigValues
-	if err := DecodeString(&dst, "i="+oversized+"&v=42&f=3.25&r=22/7"); err != nil {
+	if err := DecodeString(&dst, "i="+oversized+"&v=42&f=3.25&r="+oversized+"/7"); err != nil {
 		t.Fatal(err)
 	}
 	if dst.I == nil || dst.I.String() != oversized {
@@ -37,8 +38,10 @@ func TestBigDecode(t *testing.T) {
 	if dst.F == nil || dst.F.String() != "3.25" {
 		t.Errorf("*big.Float: got %v, want 3.25", dst.F)
 	}
-	if dst.R == nil || dst.R.String() != "22/7" {
-		t.Errorf("*big.Rat: got %v, want 22/7", dst.R)
+	want := new(big.Rat)
+	want.SetString(oversized + "/7")
+	if dst.R == nil || dst.R.Cmp(want) != 0 {
+		t.Errorf("*big.Rat: got %v, want %v", dst.R, want)
 	}
 }
 
@@ -95,5 +98,55 @@ func TestPrimitiveOverflowErrors(t *testing.T) {
 	}
 	if err := DecodeString(&f, "x=1e400"); err == nil {
 		t.Error("expected error decoding out-of-range float into float64")
+	}
+}
+
+// TestBigFloatPrecision pins Float's precision contract: decoding rounds to
+// the destination's precision — 64-bit mantissa when unset — a precision
+// pre-set with SetPrec is honored, and a decoded value re-encodes and
+// re-decodes to an equal value.
+func TestBigFloatPrecision(t *testing.T) {
+	const long = "3.14159265358979323846264338327950288419716939937510582097494459"
+
+	var d struct {
+		F *big.Float `form:"f"`
+	}
+	if err := DecodeString(&d, "f="+long); err != nil {
+		t.Fatal(err)
+	}
+	if d.F.Prec() != 64 {
+		t.Errorf("default precision: got %d, want 64", d.F.Prec())
+	}
+
+	var p struct {
+		F *big.Float `form:"f"`
+	}
+	p.F = new(big.Float).SetPrec(200)
+	if err := DecodeString(&p, "f="+long); err != nil {
+		t.Fatal(err)
+	}
+	if p.F.Prec() != 200 {
+		t.Errorf("pre-set precision: got %d, want 200", p.F.Prec())
+	}
+	want, _, err := big.ParseFloat(long, 10, 200, big.ToNearestEven)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.F.Cmp(want) != 0 {
+		t.Errorf("pre-set decode: got %s, want %s", p.F.Text('g', 65), want.Text('g', 65))
+	}
+
+	s, err := EncodeToString(&d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var d2 struct {
+		F *big.Float `form:"f"`
+	}
+	if err := DecodeString(&d2, s); err != nil {
+		t.Fatal(err)
+	}
+	if d.F.Cmp(d2.F) != 0 {
+		t.Errorf("round-trip: %s re-decoded as %s", d.F.Text('g', 25), d2.F.Text('g', 25))
 	}
 }


### PR DESCRIPTION
It turns out `math/big` has been fully supported for years, via the existing `encoding.TextMarshaler`/`TextUnmarshaler` path: `Int`, `Float`, and `Rat` (pointer or value fields) encode and decode losslessly at arbitrary precision with no code changes needed. This PR pins that behavior with regression tests and documents it, retiring a long-standing TODO item in spirit.

The tests pin a triad of related behaviors:

- **Typed big values round-trip** — `*big.Int`/`big.Int`/`*big.Float`/`*big.Rat` decode from and encode to their canonical text forms, including values far beyond 2^64.
- **Untyped decoding performs no numeric interpretation** — simple values are preserved as strings exactly as sent (urlencoded data carries no type information, so any interpretation would be guessing). This means numerals of any magnitude survive untyped decoding losslessly, and leading zeros are never corrupted.
- **Primitive overflow fails loudly** — decoding an oversized integer into `int64`, or an out-of-range float into `float64`, returns an error rather than silently truncating; `math/big` destinations are the documented remedy.

README gains a bullet in *Untyped Values* (no-interpretation guarantee) and a paragraph in *Custom Marshaling* (stdlib TextMarshaler types, math/big specifically).