### PR TITLE
Add error classification (form.Error.Kind); make conflicting key paths deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,9 @@ Errors
 
 Errors returned by the decoding and encoding functions are of type `*form.Error`,
 which records the operation that failed via `Op` (`form.OpDecode` or
-`form.OpEncode`) and, through `errors.Unwrap`, any underlying cause — such as an
+`form.OpEncode`), the class of failure via `Kind` (`form.KindParse`,
+`form.KindUnknownKey`, `form.KindLimit`, and so on; the zero value means
+unclassified), and, through `errors.Unwrap`, any underlying cause — such as an
 error from a `TextMarshaler`/`TextUnmarshaler` or a malformed-query error from the
 standard library. Detect and inspect them with `errors.As` and `errors.Is`. The
 message text returned by `Error` is unchanged from earlier versions, so code that

--- a/decode.go
+++ b/decode.go
@@ -45,11 +45,11 @@ func (d *Decoder) EscapeWith(r rune) *Decoder {
 func (d Decoder) Decode(dst interface{}) error {
 	bs, err := io.ReadAll(d.r)
 	if err != nil {
-		return asError(OpDecode, err)
+		return wrapKind(OpDecode, KindIO, err)
 	}
 	vs, err := url.ParseQuery(string(bs))
 	if err != nil {
-		return asError(OpDecode, err)
+		return wrapKind(OpDecode, KindSyntax, err)
 	}
 	return d.decode(reflect.ValueOf(dst), vs)
 }
@@ -126,7 +126,7 @@ func (d Decoder) depthLimit() int {
 func (d Decoder) DecodeString(dst interface{}, src string) error {
 	vs, err := url.ParseQuery(src)
 	if err != nil {
-		return asError(OpDecode, err)
+		return wrapKind(OpDecode, KindSyntax, err)
 	}
 	return d.decode(reflect.ValueOf(dst), vs)
 }
@@ -159,7 +159,7 @@ func (d Decoder) decode(v reflect.Value, vs url.Values) (err error) {
 	}()
 
 	if v.Kind() == reflect.Slice {
-		return &Error{Op: OpDecode, msg: "could not decode directly into slice; use pointer to slice"}
+		return &Error{Op: OpDecode, Kind: KindUnsupported, msg: "could not decode directly into slice; use pointer to slice"}
 	}
 	d.decodeValue(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v), d.depthLimit()))
 	return nil
@@ -191,7 +191,7 @@ func (d Decoder) decodeValue(v reflect.Value, x interface{}) {
 		} else if empty {
 			return // Allow nil interfaces only if empty.
 		} else {
-			panic("form: cannot decode non-empty value into into nil interface")
+			panic(errKind(KindUnsupported, "form: cannot decode non-empty value into nil interface"))
 		}
 	}
 
@@ -216,7 +216,7 @@ func (d Decoder) decodeValue(v reflect.Value, x interface{}) {
 	case reflect.Map:
 		d.decodeMap(v, x)
 	case reflect.Invalid, reflect.Uintptr, reflect.UnsafePointer, reflect.Chan, reflect.Func:
-		panic(t.String() + " has unsupported kind " + k.String())
+		panic(errKind(KindUnsupported, t.String()+" has unsupported kind "+k.String()))
 	default:
 		d.decodeBasic(v, x)
 	}
@@ -226,13 +226,13 @@ func (d Decoder) decodeStruct(v reflect.Value, x interface{}) {
 	t := v.Type()
 	for k, c := range getNode(x) {
 		if f, ok := findField(v, k, d.ignoreCase); !ok && k == "" {
-			panic(getString(x) + " cannot be decoded as " + t.String())
+			panic(errKind(KindParse, getString(x)+" cannot be decoded as "+t.String()))
 		} else if !ok {
 			if !d.ignoreUnknown {
-				panic(k + " doesn't exist in " + t.String())
+				panic(errKind(KindUnknownKey, k+" doesn't exist in "+t.String()))
 			}
 		} else if !f.CanSet() {
-			panic(k + " cannot be set in " + t.String())
+			panic(errKind(KindUnsupported, k+" cannot be set in "+t.String()))
 		} else {
 			d.decodeValue(f, c)
 		}
@@ -280,10 +280,10 @@ func (d Decoder) decodeArray(v reflect.Value, x interface{}) {
 	for k, c := range getNode(x) {
 		i, err := strconv.Atoi(k)
 		if err != nil || i < 0 {
-			panic(k + " is not a valid index for type " + t.String())
+			panic(errKind(KindIndex, k+" is not a valid index for type "+t.String()))
 		}
 		if l := v.Len(); i >= l {
-			panic("index is above array size")
+			panic(errKind(KindIndex, "index is above array size"))
 		}
 		d.decodeValue(v.Index(i), c)
 	}
@@ -313,21 +313,21 @@ func (d Decoder) decodeSlice(v reflect.Value, x interface{}) {
 		} else {
 			explicit, err := strconv.Atoi(k)
 			if err != nil {
-				panic(k + " is not a valid index for type " + t.String())
+				panic(errKind(KindIndex, k+" is not a valid index for type "+t.String()))
 			}
 			i = explicit
 			implicit = explicit + 1
 		}
 		if i < 0 {
-			panic(k + " is not a valid index for type " + t.String())
+			panic(errKind(KindIndex, k+" is not a valid index for type "+t.String()))
 		}
 		// Guard against a small payload forcing a huge allocation via a large
 		// explicit index. The limit tracks the number of supplied elements, so
 		// legitimately large slices are unaffected; see Decoder.MaxSize.
 		if limit >= 0 && i >= limit {
-			panic("index " + strconv.Itoa(i) + " exceeds the allowed size (" +
-				strconv.Itoa(limit) + ") for type " + t.String() +
-				"; supply more elements or set Decoder.MaxSize for trusted input")
+			panic(errKind(KindLimit, "index "+strconv.Itoa(i)+" exceeds the allowed size ("+
+				strconv.Itoa(limit)+") for type "+t.String()+
+				"; supply more elements or set Decoder.MaxSize for trusted input"))
 		}
 		// "Extend" the slice if it's too short.
 		if l := v.Len(); i >= l {
@@ -345,7 +345,7 @@ func (d Decoder) decodeBasic(v reflect.Value, x interface{}) {
 		if b, e := strconv.ParseBool(s); e == nil {
 			v.SetBool(b)
 		} else {
-			panic("could not parse bool from " + strconv.Quote(s))
+			panic(errKind(KindParse, "could not parse bool from "+strconv.Quote(s)))
 		}
 	case reflect.Int,
 		reflect.Int8,
@@ -355,7 +355,7 @@ func (d Decoder) decodeBasic(v reflect.Value, x interface{}) {
 		if i, e := strconv.ParseInt(s, 10, 64); e == nil {
 			v.SetInt(i)
 		} else {
-			panic("could not parse int from " + strconv.Quote(s))
+			panic(errKind(KindParse, "could not parse int from "+strconv.Quote(s)))
 		}
 	case reflect.Uint,
 		reflect.Uint8,
@@ -365,14 +365,14 @@ func (d Decoder) decodeBasic(v reflect.Value, x interface{}) {
 		if u, e := strconv.ParseUint(s, 10, 64); e == nil {
 			v.SetUint(u)
 		} else {
-			panic("could not parse uint from " + strconv.Quote(s))
+			panic(errKind(KindParse, "could not parse uint from "+strconv.Quote(s)))
 		}
 	case reflect.Float32,
 		reflect.Float64:
 		if f, e := strconv.ParseFloat(s, 64); e == nil {
 			v.SetFloat(f)
 		} else {
-			panic("could not parse float from " + strconv.Quote(s))
+			panic(errKind(KindParse, "could not parse float from "+strconv.Quote(s)))
 		}
 	case reflect.Complex64,
 		reflect.Complex128:
@@ -380,12 +380,12 @@ func (d Decoder) decodeBasic(v reflect.Value, x interface{}) {
 		if n, err := fmt.Sscanf(s, "%g", &c); n == 1 && err == nil {
 			v.SetComplex(c)
 		} else {
-			panic("could not parse complex from " + strconv.Quote(s))
+			panic(errKind(KindParse, "could not parse complex from "+strconv.Quote(s)))
 		}
 	case reflect.String:
 		v.SetString(s)
 	default:
-		panic(t.String() + " has unsupported kind " + k.String())
+		panic(errKind(KindUnsupported, t.String()+" has unsupported kind "+k.String()))
 	}
 }
 
@@ -399,7 +399,7 @@ func (d Decoder) decodeTime(v reflect.Value, x interface{}) {
 			return
 		}
 	}
-	panic("cannot decode string `" + s + "` as " + t.String())
+	panic(errKind(KindParse, "cannot decode string `"+s+"` as "+t.String()))
 }
 
 func (d Decoder) decodeURL(v reflect.Value, x interface{}) {
@@ -409,7 +409,7 @@ func (d Decoder) decodeURL(v reflect.Value, x interface{}) {
 		v.Set(reflect.ValueOf(*u).Convert(v.Type()))
 		return
 	}
-	panic("cannot decode string `" + s + "` as " + t.String())
+	panic(errKind(KindParse, "cannot decode string `"+s+"` as "+t.String()))
 }
 
 var allowedTimeFormats = []string{

--- a/encode.go
+++ b/encode.go
@@ -6,7 +6,6 @@ package form
 
 import (
 	"encoding"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -65,9 +64,9 @@ func (e Encoder) Encode(dst interface{}) error {
 	l, err := io.WriteString(e.w, s)
 	switch {
 	case err != nil:
-		return asError(OpEncode, err)
+		return wrapKind(OpEncode, KindIO, err)
 	case l != len(s):
-		return asError(OpEncode, errors.New("could not write data completely"))
+		return NewError(OpEncode, KindIO, nil, "could not write data completely")
 	}
 	return nil
 }
@@ -136,7 +135,7 @@ func encodeValue(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interfa
 	case reflect.Ptr:
 		ptr := v.Pointer()
 		if seen[ptr] {
-			panic("form: encoding a cycle via " + t.String())
+			panic(errKind(KindCycle, "form: encoding a cycle via "+t.String()))
 		}
 		seen[ptr] = true
 		defer delete(seen, ptr)
@@ -154,7 +153,7 @@ func encodeValue(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interfa
 		if v.Len() > 0 {
 			ptr := v.Pointer()
 			if seen[ptr] {
-				panic("form: encoding a cycle via " + t.String())
+				panic(errKind(KindCycle, "form: encoding a cycle via "+t.String()))
 			}
 			seen[ptr] = true
 			defer delete(seen, ptr)
@@ -165,13 +164,13 @@ func encodeValue(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interfa
 	case reflect.Map:
 		ptr := v.Pointer()
 		if seen[ptr] {
-			panic("form: encoding a cycle via " + t.String())
+			panic(errKind(KindCycle, "form: encoding a cycle via "+t.String()))
 		}
 		seen[ptr] = true
 		defer delete(seen, ptr)
 		return encodeMap(v, z, o, seen)
 	case reflect.Invalid, reflect.Uintptr, reflect.UnsafePointer, reflect.Chan, reflect.Func:
-		panic(t.String() + " has unsupported kind " + t.Kind().String())
+		panic(errKind(KindUnsupported, t.String()+" has unsupported kind "+t.Kind().String()))
 	default:
 		return encodeBasic(v)
 	}
@@ -420,7 +419,7 @@ func encodeBasic(v reflect.Value) string {
 	case reflect.String:
 		return v.String()
 	}
-	panic(t.String() + " has unsupported kind " + t.Kind().String())
+	panic(errKind(KindUnsupported, t.String()+" has unsupported kind "+t.Kind().String()))
 }
 
 func isEmptyValue(v reflect.Value) bool {

--- a/error.go
+++ b/error.go
@@ -14,17 +14,58 @@ const (
 	OpEncode Op = "encode"
 )
 
+// Kind classifies the failure that produced an Error. The zero value means
+// the failure is unclassified — typically an error propagated from a custom
+// TextMarshaler/TextUnmarshaler or another external source; use Unwrap (via
+// errors.As/Is) to reach the cause.
+type Kind string
+
+const (
+	// KindSyntax reports input that is not well-formed
+	// application/x-www-form-urlencoded data.
+	KindSyntax Kind = "syntax"
+
+	// KindParse reports a value that cannot be parsed as the destination
+	// type (e.g. "abc" into an int, or an invalid time).
+	KindParse Kind = "parse"
+
+	// KindUnknownKey reports a key with no corresponding destination field;
+	// see Decoder.IgnoreUnknownKeys.
+	KindUnknownKey Kind = "unknown-key"
+
+	// KindIndex reports an explicit index that is not a valid position in
+	// the destination (malformed, negative, or beyond an array's bounds).
+	KindIndex Kind = "index"
+
+	// KindLimit reports input that exceeds a decoder resource bound; see
+	// Decoder.MaxSize and Decoder.MaxDepth.
+	KindLimit Kind = "limit"
+
+	// KindUnsupported reports a destination or value that cannot be
+	// represented as form data (an unsupported kind, an unsettable field, or
+	// an invalid destination).
+	KindUnsupported Kind = "unsupported"
+
+	// KindCycle reports a self-referential value encountered while encoding.
+	KindCycle Kind = "cycle"
+
+	// KindIO reports a failure reading input or writing encoded output.
+	KindIO Kind = "io"
+)
+
 // Error is the error type returned by Decode and Encode operations for
 // malformed input or values that cannot be represented. Callers can use
-// errors.As to detect it and inspect Op, and errors.Unwrap (via Err) to reach
-// an underlying cause such as an error from a TextMarshaler or TextUnmarshaler.
+// errors.As to detect it and inspect Op and Kind, and errors.Unwrap (via
+// Err) to reach an underlying cause such as an error from a TextMarshaler or
+// TextUnmarshaler.
 //
 // The text returned by the Error method is identical to that of earlier
 // versions, so code matching on error strings is unaffected.
 type Error struct {
-	Op  Op    // the operation that failed
-	Err error // the underlying cause, if any; nil when the message originates here
-	msg string
+	Op   Op    // the operation that failed
+	Kind Kind  // the class of failure; empty when unclassified
+	Err  error // the underlying cause, if any; nil when the message originates here
+	msg  string
 }
 
 // Error returns the error message.
@@ -32,6 +73,26 @@ func (e *Error) Error() string { return e.msg }
 
 // Unwrap returns the underlying cause, enabling errors.Is and errors.As.
 func (e *Error) Unwrap() error { return e.Err }
+
+// NewError returns an *Error with the given operation, kind, underlying
+// cause (which may be nil) and message. It exists so that packages built on
+// top of form (such as form/multipart) can return errors that participate in
+// the same errors.As taxonomy.
+func NewError(op Op, kind Kind, err error, msg string) *Error {
+	return &Error{Op: op, Kind: kind, Err: err, msg: msg}
+}
+
+// errKind constructs an *Error carrying a kind and message; the operation is
+// filled in by asError when the error crosses the recover boundary.
+func errKind(kind Kind, msg string) *Error {
+	return &Error{Kind: kind, msg: msg}
+}
+
+// wrapKind wraps an external error with an operation and kind, preserving
+// its message.
+func wrapKind(op Op, kind Kind, err error) error {
+	return &Error{Op: op, Kind: kind, Err: err, msg: err.Error()}
+}
 
 // asError converts a recovered value into an *Error, preserving its message.
 func asError(op Op, v interface{}) error {

--- a/kind_test.go
+++ b/kind_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// kindOf decodes src into dst and reports the resulting *Error's Kind.
+func kindOf(t *testing.T, dst interface{}, src string) Kind {
+	t.Helper()
+	err := DecodeString(dst, src)
+	if err == nil {
+		t.Fatalf("expected an error decoding %q", src)
+	}
+	var fe *Error
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *form.Error, got %T: %v", err, err)
+	}
+	if fe.Op != OpDecode {
+		t.Errorf("Op: got %q, want %q", fe.Op, OpDecode)
+	}
+	return fe.Kind
+}
+
+func TestKinds(t *testing.T) {
+	type dst struct {
+		N  int       `form:"n"`
+		S  []int     `form:"s"`
+		A  [2]int    `form:"a"`
+		Ch chan int  `form:"ch"`
+		M  yesReader `form:"m"`
+	}
+
+	for _, c := range []struct {
+		name string
+		src  string
+		want Kind
+	}{
+		{"syntax", "n=%zz", KindSyntax},
+		{"parse", "n=abc", KindParse},
+		{"unknown key", "nope=1", KindUnknownKey},
+		{"index malformed", "s.x=1", KindIndex},
+		{"index above array", "a.5=1", KindIndex},
+		{"limit size", "s.999999999=1", KindLimit},
+		{"limit depth", strings.Repeat("q.", 10001) + "z=1", KindLimit},
+		{"unsupported", "ch=1", KindUnsupported},
+	} {
+		var d dst
+		if got := kindOf(t, &d, c.src); got != c.want {
+			t.Errorf("%s: got Kind %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestConflictingKeyPathsAreDeterministic(t *testing.T) {
+	// "a=1&a.b=2" sets the key path "a" both as a scalar and as a composite.
+	// Keys are split in sorted order, so the scalar is always absorbed and
+	// the outcome never depends on map iteration order: struct destinations
+	// always fail the same way (the absorbed composite cannot decode into
+	// the struct), and map destinations always succeed with both values.
+	for i := 0; i < 50; i++ {
+		var d struct {
+			A struct {
+				B string `form:"b"`
+			} `form:"a"`
+		}
+		err := DecodeString(&d, "a=1&a.b=2")
+		var fe *Error
+		if err == nil || !errors.As(err, &fe) || fe.Kind != KindParse {
+			t.Fatalf("struct dst: got %v, want KindParse", err)
+		}
+
+		m := map[string]interface{}{}
+		if err := DecodeString(&m, "a=1&a.b=2"); err != nil {
+			t.Fatalf("map dst: unexpected error: %v", err)
+		}
+		inner, ok := m["a"].(map[string]interface{})
+		if !ok || inner[""] != "1" || inner["b"] != "2" {
+			t.Fatalf("map dst: got %v, want both values retained", m)
+		}
+	}
+}
+
+func TestKindCycleAndIO(t *testing.T) {
+	type box struct {
+		Self *box `form:"self"`
+	}
+	b := &box{}
+	b.Self = b
+	_, err := EncodeToString(b)
+	var fe *Error
+	if err == nil || !errors.As(err, &fe) || fe.Kind != KindCycle || fe.Op != OpEncode {
+		t.Errorf("cycle: got %v", err)
+	}
+
+	if err := NewEncoder(failWriter{}).Encode(struct{ A int }{1}); err == nil {
+		t.Error("io: expected error")
+	} else if !errors.As(err, &fe) || fe.Kind != KindIO {
+		t.Errorf("io: got %v with kind %q", err, fe.Kind)
+	}
+}
+
+// TestKindUnclassified pins that external causes (e.g. a TextUnmarshaler
+// failure) keep an empty Kind and remain reachable via Unwrap.
+func TestKindUnclassified(t *testing.T) {
+	var d struct {
+		M yesReader `form:"m"`
+	}
+	err := DecodeString(&d, "m=x")
+	var fe *Error
+	if err == nil || !errors.As(err, &fe) {
+		t.Fatalf("got %v", err)
+	}
+	if fe.Kind != Kind("") {
+		t.Errorf("got Kind %q, want empty", fe.Kind)
+	}
+	if fe.Err == nil {
+		t.Error("expected wrapped cause")
+	}
+}
+
+// yesReader is a TextUnmarshaler that always fails, to exercise the
+// unclassified path.
+type yesReader struct{}
+
+func (yesReader) UnmarshalText([]byte) error { return errors.New("nope") }
+
+// TestSyntaxKindMatchesURLError pins that syntax errors wrap the underlying
+// net/url error.
+func TestSyntaxKindMatchesURLError(t *testing.T) {
+	var d struct{}
+	err := DecodeString(&d, "%zz=1")
+	var fe *Error
+	if err == nil || !errors.As(err, &fe) || fe.Kind != KindSyntax {
+		t.Fatalf("got %v", err)
+	}
+	var ue url.EscapeError
+	if !errors.As(err, &ue) {
+		t.Errorf("underlying url.EscapeError not reachable: %v", fe.Err)
+	}
+}

--- a/node.go
+++ b/node.go
@@ -6,6 +6,7 @@ package form
 
 import (
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -54,9 +55,19 @@ func parseValues(d, e rune, vs url.Values, canIndexFirstLevelOrdinally bool, max
 		}
 	}
 
+	// Split in sorted key order so outcomes never depend on map iteration
+	// order: a scalar key is a strict prefix of any composite key through it,
+	// and prefixes sort first, so the scalar is always absorbed into the node
+	// (rather than the node colliding with a later scalar).
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	n := node{}
-	for k, s := range m {
-		n = n.split(d, e, k, s, 1, maxDepth)
+	for _, k := range keys {
+		n = n.split(d, e, k, m[k], 1, maxDepth)
 	}
 	return n
 }
@@ -78,8 +89,8 @@ func splitPath(d, e rune, path string) (k, rest string) {
 
 func (n node) split(d, e rune, path, s string, depth, maxDepth int) node {
 	if maxDepth >= 0 && depth > maxDepth {
-		panic("key path nesting exceeds the maximum depth (" + strconv.Itoa(maxDepth) +
-			"); set Decoder.MaxDepth for trusted input")
+		panic(errKind(KindLimit, "key path nesting exceeds the maximum depth ("+strconv.Itoa(maxDepth)+
+			"); set Decoder.MaxDepth for trusted input"))
 	}
 	k, rest := splitPath(d, e, path)
 	if rest == "" {
@@ -100,7 +111,7 @@ func add(n node, k, s string) node {
 	}
 
 	if _, ok := n[k]; ok {
-		panic("key " + k + " already set")
+		panic("key " + k + " already set") // Unreachable: sorted splitting absorbs scalars first.
 	}
 
 	n[k] = s


### PR DESCRIPTION
Two related changes, found together.

**1. Error classification.** Adds a `Kind` field to `form.Error` and a `NewError` constructor so packages built on form (next: `form/multipart`) can mint errors in the same `errors.As` taxonomy. Kinds: `KindSyntax` (malformed urlencoded input), `KindParse` (value can't be parsed as the destination type), `KindUnknownKey`, `KindIndex` (invalid/out-of-range explicit index), `KindLimit` (MaxSize/MaxDepth bounds), `KindUnsupported` (unrepresentable destination/value), `KindCycle` (self-referential value on encode), `KindIO` (read/write failure). The zero value means unclassified — notably errors propagated from custom `TextMarshaler`/`TextUnmarshaler` implementations, still reachable via `errors.Unwrap`. Classified failure sites now panic with a typed `*Error` carrying the exact same message text as before; the recover boundary fills in `Op`. Error message strings are unchanged — code matching on them is unaffected — with one deliberate exception: the doubled word in "…value into into nil interface" is fixed.

**2. Deterministic handling of conflicting key paths.** Writing kind tests exposed a latent, pre-existing bug: for input that sets a key path both as a scalar and as a composite (`a=1&a.b=2`), the outcome depended on Go map iteration order. Struct destinations nondeterministically got one of two different error messages, and **map destinations nondeterministically succeeded (~79%) or failed (~21%)** across 400 trials on current master. Fix: `parseValues` now splits keys in sorted order. A scalar key is a strict prefix of any composite key through it, and prefixes sort first, so the scalar is always absorbed into the node — same input, same outcome, every time: map destinations always succeed retaining both values; struct destinations always fail with the same `KindParse` error. Since no caller can have relied on a coin flip, this is compat-safe. (A consequence: the internal "key already set" collision becomes unreachable, so no `KindConflict` is introduced; the panic remains as an untyped defensive invariant.)

Tests pin each Kind via `errors.As`, the unclassified TextUnmarshaler path, syntax errors unwrapping to the underlying `net/url` error, and 50-iteration determinism of the conflicting-key-path case for both struct and map destinations.

README's Errors section documents `Kind`. Follow-up (separate PR, after the multipart PR merges): `form/multipart` returns `*form.Error` via `NewError`.