### PR TITLE
Decode image/color types from hex; optional hex encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ Values of the following kinds aren't supported and, if present, must be ignored.
  - An alias of any of the above
  - A pointer to any of the above
 
+### Colors
+
+The fixed-channel [`image/color`](http://golang.org/pkg/image/color/) types
+(`NRGBA`, `RGBA`, `NRGBA64`, `RGBA64`, `Gray`, `Gray16`, `Alpha`, `Alpha16`
+and `CMYK`) decode from hex strings such as those submitted by HTML
+`<input type=color>` elements — bare or `#`-prefixed, case-insensitive, with
+CSS-style shorthand (`f00`, `f00a`) accepted by the 8-bit RGBA types and an
+omitted alpha defaulting to opaque. The encoding is byte-faithful per type,
+so every value round-trips exactly; accordingly, the premultiplied types
+(`RGBA`, `RGBA64`) reject values whose color channels exceed their alpha —
+that shape almost always means straight-alpha (CSS) semantics, for which
+`NRGBA`/`NRGBA64` are the faithful destinations.
+
+The pre-existing composite representation (`c.R=255&c.G=0&…`) continues to
+decode for every color type, and remains the default encoding; opt into hex
+output with `Encoder.HexColors(true)`. Named types based on the color types
+keep the composite representation entirely.
+
 Custom Marshaling
 -----------------
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,5 +2,4 @@ TODO
 ====
 
   - An option to automatically treat all field names in `camelCase` or `underscore_case`.
-  - Built-in support for the types in [`image/color`](http://golang.org/pkg/image/color/).
   - Improve encoding/decoding by reading/writing directly from/to the `io.Reader`/`io.Writer` when possible, rather than going through an intermediate representation (i.e. `node`) which requires more memory.

--- a/color.go
+++ b/color.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"image/color"
+	"reflect"
+	"strings"
+)
+
+// The fixed-channel image/color types decode from hex strings — as submitted
+// by HTML <input type=color> elements — and can optionally encode to them
+// (see Encoder.HexColors). The encoding is byte-faithful per type: each
+// channel is written as stored, so every value round-trips exactly. Input is
+// case-insensitive, tolerates a leading '#' (never emitted), and accepts
+// CSS-style shorthand for the 8-bit RGBA types. Digit counts per type:
+//
+//	color.Gray, color.Alpha       2
+//	color.Gray16, color.Alpha16   4
+//	color.NRGBA, color.RGBA       3, 4, 6 or 8 (shorthand nibbles doubled;
+//	                              omitted alpha defaults to ff)
+//	color.NRGBA64, color.RGBA64   12 or 16 (omitted alpha defaults to ffff)
+//	color.CMYK                    8
+//
+// The premultiplied types (RGBA, RGBA64) reject values whose color channels
+// exceed their alpha, since no valid premultiplied color has that shape; it
+// almost always indicates straight-alpha (CSS) semantics, for which NRGBA
+// and NRGBA64 are the faithful destinations.
+//
+// Matching is by exact type; named types based on these fall back to the
+// generic composite-struct representation, as all struct types did before
+// hex support existed. The composite form also remains accepted on decode
+// for every color type, and remains the default encoding.
+var (
+	grayType    = reflect.TypeOf(color.Gray{})
+	gray16Type  = reflect.TypeOf(color.Gray16{})
+	alphaType   = reflect.TypeOf(color.Alpha{})
+	alpha16Type = reflect.TypeOf(color.Alpha16{})
+	nrgbaType   = reflect.TypeOf(color.NRGBA{})
+	nrgba64Type = reflect.TypeOf(color.NRGBA64{})
+	rgbaType    = reflect.TypeOf(color.RGBA{})
+	rgba64Type  = reflect.TypeOf(color.RGBA64{})
+	cmykType    = reflect.TypeOf(color.CMYK{})
+)
+
+func isColorType(t reflect.Type) bool {
+	switch t {
+	case grayType, gray16Type, alphaType, alpha16Type,
+		nrgbaType, nrgba64Type, rgbaType, rgba64Type, cmykType:
+		return true
+	}
+	return false
+}
+
+// decodeColor sets v (a fixed-channel color type) from hex string s.
+func decodeColor(v reflect.Value, s string) {
+	t := v.Type()
+	h := strings.ToLower(strings.TrimPrefix(s, "#"))
+	ns, ok := nibbles(h)
+
+	badLength := func(want string) {
+		panic(errKind(KindParse, s+" cannot be decoded as "+t.String()+
+			" (want "+want+" hex digits)"))
+	}
+	if !ok {
+		panic(errKind(KindParse, s+" cannot be decoded as "+t.String()+
+			" (not a hex string)"))
+	}
+
+	var c interface{}
+	switch t {
+	case grayType, alphaType:
+		if len(ns) != 2 {
+			badLength("2")
+		}
+		y := ns[0]<<4 | ns[1]
+		if t == grayType {
+			c = color.Gray{Y: y}
+		} else {
+			c = color.Alpha{A: y}
+		}
+	case gray16Type, alpha16Type:
+		if len(ns) != 4 {
+			badLength("4")
+		}
+		y := pack16(ns)
+		if t == gray16Type {
+			c = color.Gray16{Y: y}
+		} else {
+			c = color.Alpha16{A: y}
+		}
+	case nrgbaType, rgbaType:
+		r, g, b, a, ok := rgba8(ns)
+		if !ok {
+			badLength("3, 4, 6 or 8")
+		}
+		if t == nrgbaType {
+			c = color.NRGBA{R: r, G: g, B: b, A: a}
+		} else {
+			if r > a || g > a || b > a {
+				panic(premultErr(s, t))
+			}
+			c = color.RGBA{R: r, G: g, B: b, A: a}
+		}
+	case nrgba64Type, rgba64Type:
+		r, g, b, a, ok := rgba16(ns)
+		if !ok {
+			badLength("12 or 16")
+		}
+		if t == nrgba64Type {
+			c = color.NRGBA64{R: r, G: g, B: b, A: a}
+		} else {
+			if r > a || g > a || b > a {
+				panic(premultErr(s, t))
+			}
+			c = color.RGBA64{R: r, G: g, B: b, A: a}
+		}
+	case cmykType:
+		if len(ns) != 8 {
+			badLength("8")
+		}
+		c = color.CMYK{
+			C: ns[0]<<4 | ns[1], M: ns[2]<<4 | ns[3],
+			Y: ns[4]<<4 | ns[5], K: ns[6]<<4 | ns[7],
+		}
+	}
+	v.Set(reflect.ValueOf(c))
+}
+
+func premultErr(s string, t reflect.Type) *Error {
+	return errKind(KindParse, s+" is not a valid premultiplied "+t.String()+
+		" (a color channel exceeds alpha); use the straight-alpha color.N"+
+		strings.TrimPrefix(t.String(), "color.")+" instead, or premultiply")
+}
+
+// encodeColor renders v (a fixed-channel color type) as bare lowercase hex.
+func encodeColor(v reflect.Value) string {
+	const digits = "0123456789abcdef"
+	var bs []byte
+	appendByte := func(b uint8) {
+		bs = append(bs, digits[b>>4], digits[b&0xf])
+	}
+	appendWord := func(w uint16) {
+		appendByte(uint8(w >> 8))
+		appendByte(uint8(w))
+	}
+	switch c := v.Interface().(type) {
+	case color.Gray:
+		appendByte(c.Y)
+	case color.Alpha:
+		appendByte(c.A)
+	case color.Gray16:
+		appendWord(c.Y)
+	case color.Alpha16:
+		appendWord(c.A)
+	case color.NRGBA:
+		appendByte(c.R)
+		appendByte(c.G)
+		appendByte(c.B)
+		appendByte(c.A)
+	case color.RGBA:
+		appendByte(c.R)
+		appendByte(c.G)
+		appendByte(c.B)
+		appendByte(c.A)
+	case color.NRGBA64:
+		appendWord(c.R)
+		appendWord(c.G)
+		appendWord(c.B)
+		appendWord(c.A)
+	case color.RGBA64:
+		appendWord(c.R)
+		appendWord(c.G)
+		appendWord(c.B)
+		appendWord(c.A)
+	case color.CMYK:
+		appendByte(c.C)
+		appendByte(c.M)
+		appendByte(c.Y)
+		appendByte(c.K)
+	}
+	return string(bs)
+}
+
+// nibbles converts a hex string to nibble values; false if any rune is not a
+// hex digit.
+func nibbles(s string) ([]uint8, bool) {
+	ns := make([]uint8, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case '0' <= c && c <= '9':
+			ns = append(ns, c-'0')
+		case 'a' <= c && c <= 'f':
+			ns = append(ns, c-'a'+10)
+		default:
+			return nil, false
+		}
+	}
+	return ns, true
+}
+
+// rgba8 interprets 3/4/6/8 nibbles as 8-bit RGBA, doubling shorthand nibbles
+// and defaulting an omitted alpha to 0xff.
+func rgba8(ns []uint8) (r, g, b, a uint8, ok bool) {
+	switch len(ns) {
+	case 3:
+		return ns[0] * 0x11, ns[1] * 0x11, ns[2] * 0x11, 0xff, true
+	case 4:
+		return ns[0] * 0x11, ns[1] * 0x11, ns[2] * 0x11, ns[3] * 0x11, true
+	case 6:
+		return ns[0]<<4 | ns[1], ns[2]<<4 | ns[3], ns[4]<<4 | ns[5], 0xff, true
+	case 8:
+		return ns[0]<<4 | ns[1], ns[2]<<4 | ns[3], ns[4]<<4 | ns[5], ns[6]<<4 | ns[7], true
+	}
+	return 0, 0, 0, 0, false
+}
+
+// rgba16 interprets 12/16 nibbles as 16-bit RGBA, defaulting an omitted
+// alpha to 0xffff.
+func rgba16(ns []uint8) (r, g, b, a uint16, ok bool) {
+	switch len(ns) {
+	case 12:
+		return pack16(ns[0:4]), pack16(ns[4:8]), pack16(ns[8:12]), 0xffff, true
+	case 16:
+		return pack16(ns[0:4]), pack16(ns[4:8]), pack16(ns[8:12]), pack16(ns[12:16]), true
+	}
+	return 0, 0, 0, 0, false
+}
+
+func pack16(ns []uint8) uint16 {
+	return uint16(ns[0])<<12 | uint16(ns[1])<<8 | uint16(ns[2])<<4 | uint16(ns[3])
+}

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"errors"
+	"image/color"
+	"testing"
+)
+
+type palette struct {
+	G   color.Gray    `form:"g"`
+	G16 color.Gray16  `form:"g16"`
+	A   color.Alpha   `form:"a"`
+	A16 color.Alpha16 `form:"a16"`
+	N   color.NRGBA   `form:"n"`
+	N64 color.NRGBA64 `form:"n64"`
+	P   color.RGBA    `form:"p"`
+	P64 color.RGBA64  `form:"p64"`
+	K   color.CMYK    `form:"k"`
+}
+
+func TestColorDecode(t *testing.T) {
+	var dst palette
+	err := DecodeString(&dst,
+		"g=7f&g16=7fff&a=80&a16=8000&n=ff007f80&n64=ffff00007fff8000&p=80004080&p64=80000000400a8000&k=ff00807f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Gray", dst.G, color.Gray{Y: 0x7f}},
+		{"Gray16", dst.G16, color.Gray16{Y: 0x7fff}},
+		{"Alpha", dst.A, color.Alpha{A: 0x80}},
+		{"Alpha16", dst.A16, color.Alpha16{A: 0x8000}},
+		{"NRGBA", dst.N, color.NRGBA{R: 0xff, G: 0x00, B: 0x7f, A: 0x80}},
+		{"NRGBA64", dst.N64, color.NRGBA64{R: 0xffff, G: 0x0000, B: 0x7fff, A: 0x8000}},
+		{"RGBA", dst.P, color.RGBA{R: 0x80, G: 0x00, B: 0x40, A: 0x80}},
+		{"RGBA64", dst.P64, color.RGBA64{R: 0x8000, G: 0x0000, B: 0x400a, A: 0x8000}},
+		{"CMYK", dst.K, color.CMYK{C: 0xff, M: 0x00, Y: 0x80, K: 0x7f}},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s: got %+v, want %+v", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestColorDecodeLenient(t *testing.T) {
+	// A leading '#' (as HTML <input type=color> submits), uppercase, and
+	// CSS shorthand are all accepted.
+	var dst struct {
+		N color.NRGBA `form:"n"`
+	}
+	for src, want := range map[string]color.NRGBA{
+		"%23ff007f": {R: 0xff, G: 0x00, B: 0x7f, A: 0xff}, // "#ff007f"
+		"FF007F80":  {R: 0xff, G: 0x00, B: 0x7f, A: 0x80},
+		"f07":       {R: 0xff, G: 0x00, B: 0x77, A: 0xff},
+		"f078":      {R: 0xff, G: 0x00, B: 0x77, A: 0x88},
+		"":          {},
+	} {
+		dst.N = color.NRGBA{R: 1} // Ensure the field is actually written.
+		if err := DecodeString(&dst, "n="+src); err != nil {
+			t.Errorf("%q: unexpected error: %v", src, err)
+		} else if dst.N != want {
+			t.Errorf("%q: got %+v, want %+v", src, dst.N, want)
+		}
+	}
+}
+
+func TestColorDecodeErrors(t *testing.T) {
+	var dst struct {
+		N color.NRGBA `form:"n"`
+		P color.RGBA  `form:"p"`
+	}
+	for name, src := range map[string]string{
+		"bad digits":   "n=zz0000",
+		"bad length":   "n=ff000",
+		"way too long": "n=ff0000ff00",
+	} {
+		err := DecodeString(&dst, src)
+		var fe *Error
+		if err == nil || !errors.As(err, &fe) || fe.Kind != KindParse {
+			t.Errorf("%s (%q): got %v, want KindParse", name, src, err)
+		}
+	}
+
+	// A premultiplied color with a channel above alpha is rejected loudly:
+	// it is almost always a straight-alpha value aimed at the wrong type.
+	err := DecodeString(&dst, "p=ff000080")
+	var fe *Error
+	if err == nil || !errors.As(err, &fe) || fe.Kind != KindParse {
+		t.Fatalf("premultiplied: got %v, want KindParse", err)
+	}
+
+	// The same value is valid for the straight-alpha type.
+	if err := DecodeString(&dst, "n=ff000080"); err != nil {
+		t.Errorf("straight alpha: unexpected error: %v", err)
+	}
+}
+
+func TestColorCompositeStillDecodes(t *testing.T) {
+	// The pre-existing generic struct representation keeps working.
+	var dst struct {
+		P color.RGBA `form:"p"`
+	}
+	if err := DecodeString(&dst, "p.R=255&p.G=10&p.B=20&p.A=255"); err != nil {
+		t.Fatal(err)
+	}
+	if (dst.P != color.RGBA{R: 255, G: 10, B: 20, A: 255}) {
+		t.Errorf("got %+v", dst.P)
+	}
+}
+
+func TestColorEncodeDefaultIsComposite(t *testing.T) {
+	// Without HexColors, the wire format is unchanged from prior versions.
+	src := struct {
+		N color.NRGBA `form:"n"`
+	}{color.NRGBA{R: 255, G: 10, B: 20, A: 255}}
+	s, err := EncodeToString(&src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "n.A=255&n.B=20&n.G=10&n.R=255" {
+		t.Errorf("composite default changed: %q", s)
+	}
+}
+
+func TestColorEncodeHexAndRoundTrip(t *testing.T) {
+	src := palette{
+		G:   color.Gray{Y: 0x7f},
+		G16: color.Gray16{Y: 0x7fff},
+		A:   color.Alpha{A: 0x80},
+		A16: color.Alpha16{A: 0x8000},
+		N:   color.NRGBA{R: 0xff, G: 0x00, B: 0x7f, A: 0x80},
+		N64: color.NRGBA64{R: 0xffff, G: 0x0000, B: 0x7fff, A: 0x8000},
+		P:   color.RGBA{R: 0x80, G: 0x00, B: 0x40, A: 0x80},
+		P64: color.RGBA64{R: 0x8000, G: 0x0000, B: 0x400a, A: 0x8000},
+		K:   color.CMYK{C: 0xff, M: 0x00, Y: 0x80, K: 0x7f},
+	}
+	var sb stringWriter
+	if err := NewEncoder(&sb).HexColors(true).Encode(&src); err != nil {
+		t.Fatal(err)
+	}
+	s := sb.String()
+
+	var dst palette
+	if err := DecodeString(&dst, s); err != nil {
+		t.Fatalf("re-decode of %q: %v", s, err)
+	}
+	if dst != src {
+		t.Errorf("round trip: got %+v, want %+v (via %q)", dst, src, s)
+	}
+}
+
+func TestColorNamedTypeFallsBack(t *testing.T) {
+	// Named types based on color types keep the generic composite
+	// representation: hex handling matches by exact type only.
+	type Tint color.NRGBA
+	src := struct {
+		T Tint `form:"t"`
+	}{Tint{R: 1, G: 2, B: 3, A: 4}}
+	var sb stringWriter
+	if err := NewEncoder(&sb).HexColors(true).Encode(&src); err != nil {
+		t.Fatal(err)
+	}
+	if s := sb.String(); s != "t.A=4&t.B=3&t.G=2&t.R=1" {
+		t.Errorf("named type: got %q, want composite form", s)
+	}
+}
+
+// stringWriter is a minimal in-memory io.Writer for encoder tests.
+type stringWriter struct{ bs []byte }
+
+func (w *stringWriter) Write(p []byte) (int, error) { w.bs = append(w.bs, p...); return len(p), nil }
+func (w *stringWriter) String() string              { return string(w.bs) }

--- a/decode.go
+++ b/decode.go
@@ -202,7 +202,9 @@ func (d Decoder) decodeValue(v reflect.Value, x interface{}) {
 
 	switch k {
 	case reflect.Struct:
-		if t.ConvertibleTo(timeType) {
+		if s, ok := x.(string); ok && isColorType(t) {
+			decodeColor(v, s)
+		} else if t.ConvertibleTo(timeType) {
 			d.decodeTime(v, x)
 		} else if t.ConvertibleTo(urlType) {
 			d.decodeURL(v, x)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"image/color"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// These tests trade the surgical style of the rest of the suite for
+// legibility: one realistic, human-readable submission decoded end to end,
+// so a reader can see at a glance what the library does with a whole form.
+
+type signup struct {
+	Name    string      `form:"name"`
+	Age     int         `form:"age"`
+	Accent  color.NRGBA `form:"accent"`  // e.g. an <input type=color> value
+	Balance *big.Int    `form:"balance"` // arbitrary precision
+	Home    url.URL     `form:"home"`
+	Since   time.Time   `form:"since"`
+	Tags    []string    `form:"tags"`
+	Address struct {
+		City string `form:"city"`
+		Zip  string `form:"zip"`
+	} `form:"address"`
+	News bool `form:"news"`
+}
+
+func TestMixedPayload(t *testing.T) {
+	// As a browser would send it (percent-encoded); shown one field per
+	// line for readability:
+	payload := "name=Alice+Liddell" +
+		"&age=30" +
+		"&accent=%2300aaff" + // "#00aaff"
+		"&balance=123456789012345678901234567890" +
+		"&home=https%3A%2F%2Fexample.com%2Falice" +
+		"&since=2016-03-24" +
+		"&tags._=go&tags._=forms" + // implicit trailing index => slice
+		"&address.city=Lisbon" +
+		"&address.zip=1100-048" +
+		"&news=true"
+
+	var got signup
+	if err := DecodeString(&got, payload); err != nil {
+		t.Fatal(err)
+	}
+
+	want := signup{
+		Name:    "Alice Liddell",
+		Age:     30,
+		Accent:  color.NRGBA{R: 0x00, G: 0xaa, B: 0xff, A: 0xff},
+		Balance: bigInt(t, "123456789012345678901234567890"),
+		Home:    url.URL{Scheme: "https", Host: "example.com", Path: "/alice"},
+		Since:   time.Date(2016, 3, 24, 0, 0, 0, 0, time.UTC),
+		Tags:    []string{"go", "forms"},
+		News:    true,
+	}
+	want.Address.City = "Lisbon"
+	want.Address.Zip = "1100-048"
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("decoded submission diverges:\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestEndToEndHTTP round-trips through an actual HTTP server: a client posts
+// a form, the handler decodes the request body directly, exactly as the
+// README suggests.
+func TestEndToEndHTTP(t *testing.T) {
+	type subscription struct {
+		Email  string      `form:"email"`
+		Accent color.NRGBA `form:"accent"`
+		Plan   string      `form:"plan"`
+	}
+
+	var got subscription
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := NewDecoder(r.Body).Decode(&got); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	resp, err := http.PostForm(srv.URL, url.Values{
+		"email":  {"alice@example.com"},
+		"accent": {"#ff8800"},
+		"plan":   {"pro"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("handler rejected the form: %d", resp.StatusCode)
+	}
+
+	want := subscription{
+		Email:  "alice@example.com",
+		Accent: color.NRGBA{R: 0xff, G: 0x88, B: 0x00, A: 0xff},
+		Plan:   "pro",
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func bigInt(t *testing.T, s string) *big.Int {
+	t.Helper()
+	i, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		t.Fatalf("bad big.Int literal %q", s)
+	}
+	return i
+}

--- a/encode.go
+++ b/encode.go
@@ -17,7 +17,7 @@ import (
 
 // NewEncoder returns a new form Encoder.
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{w, defaultDelimiter, defaultEscape, false, false}
+	return &Encoder{w: w, d: defaultDelimiter, e: defaultEscape}
 }
 
 // Encoder provides a way to encode to a Writer.
@@ -27,6 +27,7 @@ type Encoder struct {
 	e rune
 	z bool
 	o bool
+	h bool
 }
 
 // DelimitWith sets r as the delimiter used for composite keys by Encoder e and returns the latter; it is '.' by default.
@@ -47,6 +48,16 @@ func (e *Encoder) KeepZeros(z bool) *Encoder {
 	return e
 }
 
+// HexColors makes the Encoder render the fixed-channel image/color types as
+// bare lowercase hex strings (e.g. color.NRGBA => "ff007f80"; see color.go
+// for the per-type formats) instead of as composite structs (C.R=255&C.G=0&…).
+// It is false by default, preserving the existing composite wire format for
+// current consumers. Decoding accepts both representations regardless.
+func (e *Encoder) HexColors(h bool) *Encoder {
+	e.h = h
+	return e
+}
+
 // OmitEmpty sets whether Encoder e should omit empty (zero) struct fields during encoding, and returns the former; this is equivalent to having ",omitempty" on every field. By default, empty fields are included.
 func (e *Encoder) OmitEmpty(o bool) *Encoder {
 	e.o = o
@@ -56,7 +67,7 @@ func (e *Encoder) OmitEmpty(o bool) *Encoder {
 // Encode encodes dst as form and writes it out using the Encoder's Writer.
 func (e Encoder) Encode(dst interface{}) error {
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, e.z, e.o)
+	n, err := encodeToNode(v, encOpts{keepZeros: e.z, omitEmpty: e.o, hexColors: e.h})
 	if err != nil {
 		return err
 	}
@@ -83,7 +94,7 @@ func EncodeToString(dst interface{}, needEmptyValue ...bool) (string, error) {
 // EncodeToStringWith encodes dst as a form with delimiter d, escape e, keeping zero values if z, and returns it as a string.
 func EncodeToStringWith(dst interface{}, d rune, e rune, z bool) (string, error) {
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, z, false)
+	n, err := encodeToNode(v, encOpts{keepZeros: z})
 	if err != nil {
 		return "", err
 	}
@@ -103,7 +114,7 @@ func EncodeToValues(dst interface{}, needEmptyValue ...bool) (url.Values, error)
 // EncodeToValuesWith encodes dst as a form with delimiter d, escape e, keeping zero values if z, and returns it as Values.
 func EncodeToValuesWith(dst interface{}, d rune, e rune, z bool) (url.Values, error) {
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, z, false)
+	n, err := encodeToNode(v, encOpts{keepZeros: z})
 	if err != nil {
 		return nil, err
 	}
@@ -111,23 +122,23 @@ func EncodeToValuesWith(dst interface{}, d rune, e rune, z bool) (url.Values, er
 	return vs, nil
 }
 
-func encodeToNode(v reflect.Value, z bool, o bool) (n node, err error) {
+func encodeToNode(v reflect.Value, opts encOpts) (n node, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = asError(OpEncode, e)
 		}
 	}()
 	seen := make(map[uintptr]bool)
-	return getNode(encodeValue(v, z, o, seen)), nil
+	return getNode(encodeValue(v, opts, seen)), nil
 }
 
-func encodeValue(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interface{} {
+func encodeValue(v reflect.Value, opts encOpts, seen map[uintptr]bool) interface{} {
 	t := v.Type()
 	k := v.Kind()
 
 	if s, ok := marshalValue(v); ok {
 		return s
-	} else if !z && isEmptyValue(v) {
+	} else if !opts.keepZeros && isEmptyValue(v) {
 		return "" // Treat the zero value as the empty string.
 	}
 
@@ -139,16 +150,19 @@ func encodeValue(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interfa
 		}
 		seen[ptr] = true
 		defer delete(seen, ptr)
-		return encodeValue(v.Elem(), z, o, seen)
+		return encodeValue(v.Elem(), opts, seen)
 	case reflect.Interface:
-		return encodeValue(v.Elem(), z, o, seen)
+		return encodeValue(v.Elem(), opts, seen)
 	case reflect.Struct:
+		if opts.hexColors && isColorType(t) {
+			return encodeColor(v)
+		}
 		if t.ConvertibleTo(timeType) {
 			return encodeTime(v)
 		} else if t.ConvertibleTo(urlType) {
 			return encodeURL(v)
 		}
-		return encodeStruct(v, z, o, seen)
+		return encodeStruct(v, opts, seen)
 	case reflect.Slice:
 		if v.Len() > 0 {
 			ptr := v.Pointer()
@@ -158,9 +172,9 @@ func encodeValue(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interfa
 			seen[ptr] = true
 			defer delete(seen, ptr)
 		}
-		return encodeSlice(v, z, o, seen)
+		return encodeSlice(v, opts, seen)
 	case reflect.Array:
-		return encodeArray(v, z, o, seen)
+		return encodeArray(v, opts, seen)
 	case reflect.Map:
 		ptr := v.Pointer()
 		if seen[ptr] {
@@ -168,7 +182,7 @@ func encodeValue(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interfa
 		}
 		seen[ptr] = true
 		defer delete(seen, ptr)
-		return encodeMap(v, z, o, seen)
+		return encodeMap(v, opts, seen)
 	case reflect.Invalid, reflect.Uintptr, reflect.UnsafePointer, reflect.Chan, reflect.Func:
 		panic(errKind(KindUnsupported, t.String()+" has unsupported kind "+t.Kind().String()))
 	default:
@@ -182,7 +196,7 @@ type encoderField struct {
 	omitempty bool
 }
 
-func encodeStruct(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interface{} {
+func encodeStruct(v reflect.Value, opts encOpts, seen map[uintptr]bool) interface{} {
 	fields := collectFields(v.Type())
 	n := node{}
 	for _, f := range fields {
@@ -190,10 +204,10 @@ func encodeStruct(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interf
 		if !fv.IsValid() {
 			continue
 		}
-		if (o || f.omitempty) && isEmptyValue(fv) {
+		if (opts.omitEmpty || f.omitempty) && isEmptyValue(fv) {
 			continue
 		}
-		n[f.name] = encodeValue(fv, z, o, seen)
+		n[f.name] = encodeValue(fv, opts, seen)
 	}
 	return n
 }
@@ -348,31 +362,31 @@ func isLeafStruct(ft reflect.Type) bool {
 	return ft.Implements(textMarshalerType) || reflect.PtrTo(ft).Implements(textMarshalerType)
 }
 
-func encodeMap(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interface{} {
+func encodeMap(v reflect.Value, opts encOpts, seen map[uintptr]bool) interface{} {
 	n := node{}
 	for _, i := range v.MapKeys() {
-		k := getString(encodeValue(i, z, o, seen))
-		n[k] = encodeValue(v.MapIndex(i), z, o, seen)
+		k := getString(encodeValue(i, opts, seen))
+		n[k] = encodeValue(v.MapIndex(i), opts, seen)
 	}
 	return n
 }
 
-func encodeArray(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interface{} {
+func encodeArray(v reflect.Value, opts encOpts, seen map[uintptr]bool) interface{} {
 	n := node{}
 	for i := 0; i < v.Len(); i++ {
-		n[strconv.Itoa(i)] = encodeValue(v.Index(i), z, o, seen)
+		n[strconv.Itoa(i)] = encodeValue(v.Index(i), opts, seen)
 	}
 	return n
 }
 
-func encodeSlice(v reflect.Value, z bool, o bool, seen map[uintptr]bool) interface{} {
+func encodeSlice(v reflect.Value, opts encOpts, seen map[uintptr]bool) interface{} {
 	t := v.Type()
 	if t.Elem().Kind() == reflect.Uint8 {
 		return string(v.Bytes()) // Encode byte slices as a single string by default.
 	}
 	n := node{}
 	for i := 0; i < v.Len(); i++ {
-		n[strconv.Itoa(i)] = encodeValue(v.Index(i), z, o, seen)
+		n[strconv.Itoa(i)] = encodeValue(v.Index(i), opts, seen)
 	}
 	return n
 }
@@ -595,4 +609,11 @@ func marshalValue(v reflect.Value) (string, bool) {
 		panic(err)
 	}
 	return string(bs), true
+}
+
+// encOpts carries per-Encoder options through the encoding walk.
+type encOpts struct {
+	keepZeros bool
+	omitEmpty bool
+	hexColors bool
 }


### PR DESCRIPTION
Adds first-class support for the fixed-channel `image/color` types (`NRGBA`, `RGBA`, `NRGBA64`, `RGBA64`, `Gray`, `Gray16`, `Alpha`, `Alpha16`, `CMYK`), designed so nothing existing changes shape:

**Decoding widens; nothing breaks.** These types are plain structs with exported fields, so they have always decoded (and still decode) from the generic composite form (`c.R=255&c.G=0&…`). They now *additionally* decode from hex strings — bare or `#`-prefixed (HTML `<input type=color>` submits `#rrggbb`), case-insensitive, CSS shorthand (`f00`, `f00a`) accepted by the 8-bit RGBA types, omitted alpha defaulting to opaque. Strings that errored before now work; everything that decoded before decodes identically.

**Encoding is opt-in; the wire format is unchanged by default.** `Encoder.HexColors(true)` renders these types as bare lowercase full-width hex; the default remains the composite form current consumers rely on (pinned by a regression test). The default is a candidate to flip at a future v2 boundary.

**Fidelity over CSS-compatibility.** The encoding is byte-faithful per type — each channel as stored — so every value round-trips exactly, including premultiplied ones. Corollary: the premultiplied types (`RGBA`, `RGBA64`) reject hex values whose color channels exceed alpha (`ff000080` is not a valid premultiplied color; it is almost always a straight-alpha value aimed at the wrong type). The error says so and points at `NRGBA`. `<input type=color>` values (no alpha) mean the same thing in every type, so the mainstream path never sees this distinction.

**Exact-type matching only.** Named types based on color types keep the generic composite representation, avoiding any guess about their alpha semantics.

Internally, the encoder's positional flags (`z`, `o`) are consolidated into an `encOpts` struct while adding the `hexColors` flag — groundwork the upcoming key-mapping option also builds on.

Tests cover all nine types (decode and hex round-trip), leniency (`#`, case, shorthand, empty ⇒ zero), rejection kinds (`KindParse` for bad digits/lengths and invalid premultiplied values), composite backward-compatibility on both decode and encode-by-default, and named-type fallback.