### PR TITLE
Add KeysWith: user-supplied field-name-to-key mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,11 @@ form.NewDecoder(r).KeysWith(strcase.ToSnake) // or any func(string) string
 ```
 
 Fields with an explicit tag are exempt — tags always name keys verbatim — and
-the same function should be set on both directions for values to round-trip.
+the same function should be set on both directions for values to round-trip;
+passing nil clears the mapping. The function receives struct field names
+only, never input data; it should be deterministic and injective (distinct
+fields must map to distinct keys), and — since decoding may invoke it once
+per candidate field per incoming key — memoize it if it is expensive.
 form deliberately ships no built-in casing heuristic: word-boundary rules
 (acronyms, digits) are project-specific, and baking one in would freeze its
 inevitable edge cases into the wire format. Bring your own mapper and it is

--- a/README.md
+++ b/README.md
@@ -287,8 +287,10 @@ form.NewDecoder(r).KeysWith(strcase.ToSnake) // or any func(string) string
 Fields with an explicit tag are exempt — tags always name keys verbatim — and
 the same function should be set on both directions for values to round-trip;
 passing nil clears the mapping. The function receives struct field names
-only, never input data; it should be deterministic and injective (distinct
-fields must map to distinct keys), and — since decoding may invoke it once
+only, never input data; it should be deterministic and injective — distinct
+fields must map to distinct keys, including any explicitly tagged names —
+should avoid emitting the reserved implicit-index key `_` or the delimiter
+rune, and — since decoding may invoke it once
 per candidate field per incoming key — memoize it if it is expensive.
 form deliberately ships no built-in casing heuristic: word-boundary rules
 (acronyms, digits) are project-specific, and baking one in would freeze its

--- a/README.md
+++ b/README.md
@@ -272,6 +272,25 @@ Custom:  foo.bar%2Fqux=XYZ
 
 (`%5C` and `%2F` represent `\` and `/`, respectively.)
 
+Key Mapping
+-----------
+
+When a wire naming convention differs from Go's — snake_case being the usual
+case — `KeysWith` on both `Decoder` and `Encoder` sets a transformation
+applied to struct field names, at every nesting level, to obtain their form
+keys:
+
+```go
+form.NewDecoder(r).KeysWith(strcase.ToSnake) // or any func(string) string
+```
+
+Fields with an explicit tag are exempt — tags always name keys verbatim — and
+the same function should be set on both directions for values to round-trip.
+form deliberately ships no built-in casing heuristic: word-boundary rules
+(acronyms, digits) are project-specific, and baking one in would freeze its
+inevitable edge cases into the wire format. Bring your own mapper and it is
+applied mechanically.
+
 Unknown Keys and Case
 ---------------------
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 TODO
 ====
 
-  - An option to automatically treat all field names in `camelCase` or `underscore_case`.
   - Improve encoding/decoding by reading/writing directly from/to the `io.Reader`/`io.Writer` when possible, rather than going through an intermediate representation (i.e. `node`) which requires more memory.

--- a/decode.go
+++ b/decode.go
@@ -103,9 +103,12 @@ func (d *Decoder) MaxSize(maxSize int) *Decoder {
 //
 // Passing nil clears the transformation, restoring default field-name
 // matching. f is only ever called with struct field names — never with
-// input data — and must be deterministic and injective over a struct's
-// untagged field names: unstable or colliding outputs yield unspecified
-// (though safe) matching. A panic inside f is recovered into a *Error like
+// input data — and must be deterministic, return non-empty keys, and be
+// injective over a struct's field names, tagged ones included: unstable or
+// colliding outputs yield unspecified (though safe) matching. Outputs
+// should avoid the reserved implicit-index key "_" and the delimiter rune
+// (a delimiter within a mapped name is escaped on the wire, which other
+// consumers may not expect). A panic inside f is recovered into a *Error like
 // any other decoding failure.
 //
 // The same transformation should be set on the Encoder (see

--- a/decode.go
+++ b/decode.go
@@ -101,6 +101,13 @@ func (d *Decoder) MaxSize(maxSize int) *Decoder {
 //
 //	d.KeysWith(strcase.ToSnake) // or any func(string) string
 //
+// Passing nil clears the transformation, restoring default field-name
+// matching. f is only ever called with struct field names — never with
+// input data — and must be deterministic and injective over a struct's
+// untagged field names: unstable or colliding outputs yield unspecified
+// (though safe) matching. A panic inside f is recovered into a *Error like
+// any other decoding failure.
+//
 // The same transformation should be set on the Encoder (see
 // Encoder.KeysWith) for values to round-trip. Configure IgnoreCase
 // separately if case-insensitive matching of the transformed keys is also

--- a/decode.go
+++ b/decode.go
@@ -15,7 +15,7 @@ import (
 
 // NewDecoder returns a new form Decoder.
 func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r, defaultDelimiter, defaultEscape, false, false, defaultMaxSize, defaultMaxDepth}
+	return &Decoder{r: r, d: defaultDelimiter, e: defaultEscape}
 }
 
 // Decoder decodes data from a form (application/x-www-form-urlencoded).
@@ -27,6 +27,7 @@ type Decoder struct {
 	ignoreCase    bool
 	maxSize       int
 	maxDepth      int
+	keyFn         func(string) string
 }
 
 // DelimitWith sets r as the delimiter used for composite keys by Decoder d and returns the latter; it is '.' by default.
@@ -79,6 +80,22 @@ func (d *Decoder) IgnoreCase(ignoreCase bool) {
 // input.
 func (d *Decoder) MaxSize(maxSize int) *Decoder {
 	d.maxSize = maxSize
+	return d
+}
+
+// KeysWith sets f as a transformation applied to struct field names — at
+// every nesting level — to obtain their form keys, and returns the Decoder.
+// Fields with an explicit tag are exempt: tags always name keys verbatim.
+// Use it to map Go naming to a wire convention, e.g. snake_case:
+//
+//	d.KeysWith(strcase.ToSnake) // or any func(string) string
+//
+// The same transformation should be set on the Encoder (see
+// Encoder.KeysWith) for values to round-trip. Configure IgnoreCase
+// separately if case-insensitive matching of the transformed keys is also
+// desired.
+func (d *Decoder) KeysWith(f func(string) string) *Decoder {
+	d.keyFn = f
 	return d
 }
 
@@ -227,7 +244,7 @@ func (d Decoder) decodeValue(v reflect.Value, x interface{}) {
 func (d Decoder) decodeStruct(v reflect.Value, x interface{}) {
 	t := v.Type()
 	for k, c := range getNode(x) {
-		if f, ok := findField(v, k, d.ignoreCase); !ok && k == "" {
+		if f, ok := findField(v, k, d.ignoreCase, d.keyFn); !ok && k == "" {
 			panic(errKind(KindParse, getString(x)+" cannot be decoded as "+t.String()))
 		} else if !ok {
 			if !d.ignoreUnknown {

--- a/encode.go
+++ b/encode.go
@@ -52,8 +52,12 @@ func (e *Encoder) KeepZeros(z bool) *Encoder {
 // KeysWith sets f as a transformation applied to struct field names — at
 // every nesting level — to obtain their form keys, and returns the Encoder.
 // Fields with an explicit tag are exempt: tags always name keys verbatim.
-// Set the same transformation on the Decoder (see Decoder.KeysWith) for
-// values to round-trip.
+// Passing nil clears the transformation. f is only ever called with struct
+// field names — never with data being encoded — and must be deterministic
+// and injective over a struct's untagged field names; colliding outputs
+// yield an unspecified (though safe) result. A panic inside f is recovered
+// into a *Error. Set the same transformation on the Decoder (see
+// Decoder.KeysWith) for values to round-trip.
 func (e *Encoder) KeysWith(f func(string) string) *Encoder {
 	e.kf = f
 	return e

--- a/encode.go
+++ b/encode.go
@@ -22,12 +22,13 @@ func NewEncoder(w io.Writer) *Encoder {
 
 // Encoder provides a way to encode to a Writer.
 type Encoder struct {
-	w io.Writer
-	d rune
-	e rune
-	z bool
-	o bool
-	h bool
+	w  io.Writer
+	d  rune
+	e  rune
+	z  bool
+	o  bool
+	h  bool
+	kf func(string) string
 }
 
 // DelimitWith sets r as the delimiter used for composite keys by Encoder e and returns the latter; it is '.' by default.
@@ -45,6 +46,16 @@ func (e *Encoder) EscapeWith(r rune) *Encoder {
 // KeepZeros sets whether Encoder e should keep zero (default) values in their literal form when encoding, and returns the former; by default zero values are not kept, but are rather encoded as the empty string.
 func (e *Encoder) KeepZeros(z bool) *Encoder {
 	e.z = z
+	return e
+}
+
+// KeysWith sets f as a transformation applied to struct field names — at
+// every nesting level — to obtain their form keys, and returns the Encoder.
+// Fields with an explicit tag are exempt: tags always name keys verbatim.
+// Set the same transformation on the Decoder (see Decoder.KeysWith) for
+// values to round-trip.
+func (e *Encoder) KeysWith(f func(string) string) *Encoder {
+	e.kf = f
 	return e
 }
 
@@ -67,7 +78,7 @@ func (e *Encoder) OmitEmpty(o bool) *Encoder {
 // Encode encodes dst as form and writes it out using the Encoder's Writer.
 func (e Encoder) Encode(dst interface{}) error {
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, encOpts{keepZeros: e.z, omitEmpty: e.o, hexColors: e.h})
+	n, err := encodeToNode(v, encOpts{keepZeros: e.z, omitEmpty: e.o, hexColors: e.h, keyFn: e.kf})
 	if err != nil {
 		return err
 	}
@@ -194,6 +205,7 @@ type encoderField struct {
 	index     []int
 	name      string
 	omitempty bool
+	tagged    bool
 }
 
 func encodeStruct(v reflect.Value, opts encOpts, seen map[uintptr]bool) interface{} {
@@ -207,7 +219,11 @@ func encodeStruct(v reflect.Value, opts encOpts, seen map[uintptr]bool) interfac
 		if (opts.omitEmpty || f.omitempty) && isEmptyValue(fv) {
 			continue
 		}
-		n[f.name] = encodeValue(fv, opts, seen)
+		name := f.name
+		if opts.keyFn != nil && !f.tagged {
+			name = opts.keyFn(name)
+		}
+		n[name] = encodeValue(fv, opts, seen)
 	}
 	return n
 }
@@ -280,6 +296,7 @@ func collectFields(t reflect.Type) []encoderField {
 						index:     idx,
 						name:      k,
 						omitempty: oe,
+						tagged:    tagged,
 					},
 					depth:  item.depth,
 					tagged: tagged,
@@ -504,7 +521,7 @@ func fieldInfo(f reflect.StructField, tagName ...string) (k string, oe bool) {
 	return k, oe
 }
 
-func findField(v reflect.Value, n string, ignoreCase bool) (reflect.Value, bool) {
+func findField(v reflect.Value, n string, ignoreCase bool, keyFn func(string) string) (reflect.Value, bool) {
 	t := v.Type()
 	l := v.NumField()
 
@@ -520,7 +537,11 @@ func findField(v reflect.Value, n string, ignoreCase bool) (reflect.Value, bool)
 		k, _ := fieldInfo(f)
 		if k == omittedKey {
 			continue
-		} else if n == k {
+		}
+		if keyFn != nil && !hasExplicitTag(f) {
+			k = keyFn(k)
+		}
+		if n == k {
 			return v.Field(i), true
 		} else if ignoreCase && lowerN == strings.ToLower(k) {
 			caseInsensitiveMatch = i
@@ -549,7 +570,7 @@ func findField(v reflect.Value, n string, ignoreCase bool) (reflect.Value, bool)
 		if fk != reflect.Struct {
 			continue
 		}
-		if ev, ok := findField(fv, n, ignoreCase); ok {
+		if ev, ok := findField(fv, n, ignoreCase, keyFn); ok {
 			return ev, true
 		}
 	}
@@ -616,4 +637,5 @@ type encOpts struct {
 	keepZeros bool
 	omitEmpty bool
 	hexColors bool
+	keyFn     func(string) string
 }

--- a/encode.go
+++ b/encode.go
@@ -53,9 +53,11 @@ func (e *Encoder) KeepZeros(z bool) *Encoder {
 // every nesting level — to obtain their form keys, and returns the Encoder.
 // Fields with an explicit tag are exempt: tags always name keys verbatim.
 // Passing nil clears the transformation. f is only ever called with struct
-// field names — never with data being encoded — and must be deterministic
-// and injective over a struct's untagged field names; colliding outputs
-// yield an unspecified (though safe) result. A panic inside f is recovered
+// field names — never with data being encoded — and must be deterministic,
+// return non-empty keys, and be injective over a struct's field names,
+// tagged ones included; colliding outputs yield an unspecified (though
+// safe) result, and outputs should avoid the reserved implicit-index key
+// "_" and the delimiter rune. A panic inside f is recovered
 // into a *Error. Set the same transformation on the Decoder (see
 // Decoder.KeysWith) for values to round-trip.
 func (e *Encoder) KeysWith(f func(string) string) *Encoder {

--- a/keys_test.go
+++ b/keys_test.go
@@ -149,3 +149,51 @@ func TestKeysWithPanickingMapper(t *testing.T) {
 		t.Errorf("encode: panicking mapper must become a typed error, got %v", err)
 	}
 }
+
+// TestKeysWithBeforeAndAfter is the specification at a glance: one struct,
+// encoded first without a mapper (keys are the Go field names) and then with
+// the snake mapper (keys are the wire convention), each as an exact, full
+// payload — and the mapped payload decodes back to the identical struct.
+func TestKeysWithBeforeAndAfter(t *testing.T) {
+	src := account{
+		UserName: "alice", // tagged `form:"explicit"`: exempt from mapping
+		HomeCity: "lisbon",
+		Profile:  profile{AvatarUrl: "http://x", Age: 30},
+	}
+
+	// Before — no mapper; keys are the field names themselves:
+	var before stringWriter
+	if err := NewEncoder(&before).Encode(&src); err != nil {
+		t.Fatal(err)
+	}
+	const wireBefore = "HomeCity=lisbon" +
+		"&Profile.Age=30" +
+		"&Profile.AvatarUrl=http%3A%2F%2Fx" +
+		"&explicit=alice"
+	if before.String() != wireBefore {
+		t.Errorf("without mapper:\n got  %q\n want %q", before.String(), wireBefore)
+	}
+
+	// After — with the snake mapper; same struct, wire-convention keys
+	// (the tagged field is untouched):
+	var after stringWriter
+	if err := NewEncoder(&after).KeysWith(snake).Encode(&src); err != nil {
+		t.Fatal(err)
+	}
+	const wireAfter = "explicit=alice" +
+		"&home_city=lisbon" +
+		"&profile.age=30" +
+		"&profile.avatar_url=http%3A%2F%2Fx"
+	if after.String() != wireAfter {
+		t.Errorf("with mapper:\n got  %q\n want %q", after.String(), wireAfter)
+	}
+
+	// And back: the mapped payload decodes to the identical struct.
+	var got account
+	if err := NewDecoder(nil).KeysWith(snake).DecodeString(&got, wireAfter); err != nil {
+		t.Fatal(err)
+	}
+	if got != src {
+		t.Errorf("round trip:\n got  %+v\n want %+v", got, src)
+	}
+}

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// snake is a deliberately simple example mapper: an underscore before every
+// non-initial uppercase rune, then lowercase. (Real users may prefer a
+// library with initialism handling; form only requires consistency, not
+// linguistic taste.)
+func snake(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) && i > 0 {
+			b.WriteByte('_')
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}
+
+type account struct {
+	UserName string `form:"explicit"` // Tagged: exempt from the mapping.
+	HomeCity string
+	Profile  profile
+}
+
+type profile struct {
+	AvatarUrl string
+	Age       int
+}
+
+func TestKeysWithDecode(t *testing.T) {
+	var dst account
+	d := NewDecoder(nil).KeysWith(snake)
+	err := d.DecodeString(&dst, "explicit=alice&home_city=lisbon&profile.avatar_url=http%3A%2F%2Fx&profile.age=30")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dst.UserName != "alice" || dst.HomeCity != "lisbon" ||
+		dst.Profile.AvatarUrl != "http://x" || dst.Profile.Age != 30 {
+		t.Errorf("got %+v", dst)
+	}
+}
+
+func TestKeysWithEncodeAndRoundTrip(t *testing.T) {
+	src := account{
+		UserName: "alice",
+		HomeCity: "lisbon",
+		Profile:  profile{AvatarUrl: "http://x", Age: 30},
+	}
+	var sb stringWriter
+	if err := NewEncoder(&sb).KeysWith(snake).Encode(&src); err != nil {
+		t.Fatal(err)
+	}
+	s := sb.String()
+	for _, want := range []string{"explicit=alice", "home_city=lisbon", "profile.avatar_url=", "profile.age=30"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("encoded %q lacks %q", s, want)
+		}
+	}
+
+	var dst account
+	if err := NewDecoder(nil).KeysWith(snake).DecodeString(&dst, s); err != nil {
+		t.Fatalf("re-decode of %q: %v", s, err)
+	}
+	if dst != src {
+		t.Errorf("round trip: got %+v, want %+v", dst, src)
+	}
+}
+
+func TestKeysWithTagsExempt(t *testing.T) {
+	// The tag names the key verbatim: the mapper must not apply, so the
+	// mapped spelling of the field name is an unknown key.
+	var dst account
+	err := NewDecoder(nil).KeysWith(snake).DecodeString(&dst, "user_name=alice")
+	if err == nil {
+		t.Error("expected unknown-key error for mapped spelling of a tagged field")
+	}
+}
+
+func TestKeysWithUntransformedKeyNoLongerMatches(t *testing.T) {
+	// With a mapper set, the raw field name is not a valid key.
+	var dst account
+	err := NewDecoder(nil).KeysWith(snake).DecodeString(&dst, "HomeCity=lisbon")
+	if err == nil {
+		t.Error("expected unknown-key error for untransformed field name")
+	}
+}
+
+func TestKeysWithNilIsIdentity(t *testing.T) {
+	// Without a mapper, behavior is exactly as before.
+	var dst account
+	if err := DecodeString(&dst, "HomeCity=lisbon"); err != nil {
+		t.Fatal(err)
+	}
+	if dst.HomeCity != "lisbon" {
+		t.Errorf("got %+v", dst)
+	}
+}
+
+func TestKeysWithIgnoreCaseComposes(t *testing.T) {
+	// IgnoreCase applies to the transformed keys.
+	var dst account
+	d := NewDecoder(nil).KeysWith(snake)
+	d.IgnoreCase(true)
+	if err := d.DecodeString(&dst, "HOME_CITY=lisbon"); err != nil {
+		t.Fatal(err)
+	}
+	if dst.HomeCity != "lisbon" {
+		t.Errorf("got %+v", dst)
+	}
+}

--- a/keys_test.go
+++ b/keys_test.go
@@ -5,6 +5,7 @@
 package form
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"unicode"
@@ -115,5 +116,36 @@ func TestKeysWithIgnoreCaseComposes(t *testing.T) {
 	}
 	if dst.HomeCity != "lisbon" {
 		t.Errorf("got %+v", dst)
+	}
+}
+
+func TestKeysWithNilClears(t *testing.T) {
+	d := NewDecoder(nil).KeysWith(snake)
+	var v account
+	if err := d.DecodeString(&v, "home_city=a"); err != nil {
+		t.Fatalf("mapped: %v", err)
+	}
+	d.KeysWith(nil)
+	v = account{}
+	if err := d.DecodeString(&v, "HomeCity=b"); err != nil || v.HomeCity != "b" {
+		t.Errorf("nil should restore default matching: err=%v v=%+v", err, v)
+	}
+	if err := d.DecodeString(&v, "home_city=c"); err == nil {
+		t.Error("after clearing, the mapped spelling should be unknown again")
+	}
+}
+
+func TestKeysWithPanickingMapper(t *testing.T) {
+	boom := func(s string) string { panic("mapper exploded on " + s) }
+	var v account
+	err := NewDecoder(nil).KeysWith(boom).DecodeString(&v, "home_city=x")
+	var fe *Error
+	if err == nil || !errors.As(err, &fe) || fe.Op != OpDecode {
+		t.Errorf("decode: panicking mapper must become a typed error, got %v", err)
+	}
+	var sb stringWriter
+	err = NewEncoder(&sb).KeysWith(boom).Encode(&account{HomeCity: "x"})
+	if err == nil || !errors.As(err, &fe) || fe.Op != OpEncode {
+		t.Errorf("encode: panicking mapper must become a typed error, got %v", err)
 	}
 }


### PR DESCRIPTION
Adds `KeysWith(func(string) string)` to both `Decoder` and `Encoder`: a user-supplied transformation applied to struct field names — at every nesting level — to obtain their form keys. The motivating case is wire conventions like snake_case (`HomeCity` ⇄ `home_city`).

Design choices, deliberately:

- **Explicit beats heuristic.** form ships no built-in casing algorithm. Word-boundary rules (acronyms like `UserID`, digits like `OAuth2`) are project-specific, existing Go libraries disagree on them, and baking a heuristic into a codec freezes its edge cases into the wire format forever — any later "fix" would silently change encodings. `KeysWith` keeps form mechanical: the user owns the mapping, form applies it.
- **Tags are exempt.** An explicit `form`/`json` tag names its key verbatim; the mapper applies only to untagged fields. Tags remain the per-field override.
- **Symmetric by construction.** The same function set on both `Decoder` and `Encoder` round-trips; no inverse function is ever needed (decoding transforms candidate field names and compares against incoming keys).
- **Composes with IgnoreCase**, which then applies to the transformed keys.
- **Nil is identity**: without a mapper, behavior is byte-for-byte unchanged.

Internally this builds on the `encOpts` consolidation from the colors PR (adds `keyFn`), threads a parameter through `findField`, and records on cached `encoderField`s whether their name came from a tag.

Tests cover decode and encode round-trips (including nested structs), tag exemption (mapped spelling of a tagged field is an unknown key), the raw field name no longer matching when a mapper is set, nil-mapper identity, and composition with `IgnoreCase`. README gains a "Key Mapping" section, which also states the no-built-in-heuristic policy and its rationale — retiring the auto-casing TODO item by design decision (its line is struck here).