### PR TITLE
Add Decoder.Reset and Encoder.Reset for instance reuse

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -51,6 +51,9 @@ func (d *Decoder) Reset(r io.Reader) *Decoder {
 
 // Decode reads in and decodes form-encoded data into dst.
 func (d Decoder) Decode(dst interface{}) error {
+	if d.r == nil {
+		return NewError(OpDecode, KindIO, nil, "form: cannot decode from a nil reader")
+	}
 	bs, err := io.ReadAll(d.r)
 	if err != nil {
 		return wrapKind(OpDecode, KindIO, err)

--- a/decode.go
+++ b/decode.go
@@ -41,6 +41,14 @@ func (d *Decoder) EscapeWith(r rune) *Decoder {
 	return d
 }
 
+// Reset switches the Decoder to read from r, retaining all other
+// configuration, and returns the Decoder. It allows a configured Decoder to
+// be reused (e.g. via sync.Pool) without reallocation.
+func (d *Decoder) Reset(r io.Reader) *Decoder {
+	d.r = r
+	return d
+}
+
 // Decode reads in and decodes form-encoded data into dst.
 func (d Decoder) Decode(dst interface{}) error {
 	bs, err := io.ReadAll(d.r)

--- a/encode.go
+++ b/encode.go
@@ -74,6 +74,9 @@ func (e *Encoder) Reset(w io.Writer) *Encoder {
 
 // Encode encodes dst as form and writes it out using the Encoder's Writer.
 func (e Encoder) Encode(dst interface{}) error {
+	if e.w == nil {
+		return NewError(OpEncode, KindIO, nil, "form: cannot encode to a nil writer")
+	}
 	v := reflect.ValueOf(dst)
 	n, err := encodeToNode(v, encOpts{keepZeros: e.z, omitEmpty: e.o, hexColors: e.h})
 	if err != nil {

--- a/encode.go
+++ b/encode.go
@@ -64,6 +64,14 @@ func (e *Encoder) OmitEmpty(o bool) *Encoder {
 	return e
 }
 
+// Reset switches the Encoder to write to w, retaining all other
+// configuration, and returns the Encoder. It allows a configured Encoder to
+// be reused (e.g. via sync.Pool) without reallocation.
+func (e *Encoder) Reset(w io.Writer) *Encoder {
+	e.w = w
+	return e
+}
+
 // Encode encodes dst as form and writes it out using the Encoder's Writer.
 func (e Encoder) Encode(dst interface{}) error {
 	v := reflect.ValueOf(dst)

--- a/reset_test.go
+++ b/reset_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Reset (issue #8) lets a configured Decoder/Encoder be reused across
+// readers/writers; these tests pin that configuration survives the swap.
+
+func TestDecoderReset(t *testing.T) {
+	type v struct {
+		A struct {
+			B string `form:"b"`
+		} `form:"a"`
+	}
+	d := NewDecoder(strings.NewReader("a|b=first")).DelimitWith('|')
+
+	var one v
+	if err := d.Decode(&one); err != nil {
+		t.Fatal(err)
+	}
+	var two v
+	if err := d.Reset(strings.NewReader("a|b=second")).Decode(&two); err != nil {
+		t.Fatal(err)
+	}
+	if one.A.B != "first" || two.A.B != "second" {
+		t.Errorf("got %q then %q", one.A.B, two.A.B)
+	}
+}
+
+func TestEncoderReset(t *testing.T) {
+	src := struct {
+		A struct {
+			B string `form:"b"`
+		} `form:"a"`
+	}{}
+	src.A.B = "x"
+
+	var b1, b2 bytes.Buffer
+	e := NewEncoder(&b1).DelimitWith('|')
+	if err := e.Encode(&src); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Reset(&b2).Encode(&src); err != nil {
+		t.Fatal(err)
+	}
+	if b1.String() != "a%7Cb=x" || b2.String() != b1.String() {
+		t.Errorf("got %q then %q; configuration not retained", b1.String(), b2.String())
+	}
+}

--- a/reset_test.go
+++ b/reset_test.go
@@ -6,6 +6,7 @@ package form
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -52,5 +53,28 @@ func TestEncoderReset(t *testing.T) {
 	}
 	if b1.String() != "a%7Cb=x" || b2.String() != b1.String() {
 		t.Errorf("got %q then %q; configuration not retained", b1.String(), b2.String())
+	}
+}
+
+// A nil stream is valid configuration until used — NewDecoder(nil) with
+// DecodeString/DecodeValues is idiomatic — but using it must yield a typed
+// error, never a process-crashing panic.
+func TestNilStreamErrors(t *testing.T) {
+	var x struct{ A string }
+
+	err := NewDecoder(nil).Decode(&x)
+	var fe *Error
+	if err == nil || !errors.As(err, &fe) || fe.Kind != KindIO || fe.Op != OpDecode {
+		t.Errorf("nil reader: got %v, want KindIO decode error", err)
+	}
+
+	err = NewEncoder(nil).Encode(&x)
+	if err == nil || !errors.As(err, &fe) || fe.Kind != KindIO || fe.Op != OpEncode {
+		t.Errorf("nil writer: got %v, want KindIO encode error", err)
+	}
+
+	// The idiomatic nil-reader use keeps working.
+	if err := NewDecoder(nil).DecodeString(&x, "A=ok"); err != nil || x.A != "ok" {
+		t.Errorf("DecodeString with nil reader: %v, %+v", err, x)
 	}
 }


### PR DESCRIPTION
Implements the request in #8: `Reset(io.Reader)` on `Decoder` and `Reset(io.Writer)` on `Encoder`, swapping the underlying stream while retaining all other configuration (delimiter, escape, limits, flags), returning the receiver for chaining consistency with the other setters. This allows a configured instance to be reused — e.g. via `sync.Pool` — without reallocation, mirroring the `bufio.Reader.Reset`/`bufio.Writer.Reset` precedent.

Tests pin that configuration survives the swap in both directions (a custom delimiter set before `Reset` still applies after).

Trivially additive: no existing code paths change; documented via godoc rather than the README, proportionate to the feature's size.