### PR TITLE
multipart: return *form.Error; add KeysWith passthrough

### DIFF
--- a/multipart/multipart.go
+++ b/multipart/multipart.go
@@ -26,10 +26,14 @@
 // fields that aren't interesting to model (CSRF tokens, submit-button names);
 // either add matching struct fields or opt out of strictness with
 // NewDecoder().IgnoreUnknownKeys(true).
+//
+// Errors returned by this package are of type *form.Error, carrying Op
+// (form.OpDecode) and Kind (form.KindUnknownKey, form.KindLimit, and so on),
+// so they participate in the same errors.As taxonomy as form itself. Field
+// names can be mapped to wire keys with Decoder.KeysWith, mirroring form.
 package multipart
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -65,6 +69,7 @@ var (
 type Decoder struct {
 	fd            *form.Decoder
 	ignoreUnknown bool
+	keyFn         func(string) string
 	maxFileSize   int64
 	maxFiles      int
 }
@@ -104,6 +109,17 @@ func (d *Decoder) IgnoreUnknownKeys(ignoreUnknown bool) *Decoder {
 // file fields are always matched exactly.
 func (d *Decoder) IgnoreCase(ignoreCase bool) *Decoder {
 	d.fd.IgnoreCase(ignoreCase)
+	return d
+}
+
+// KeysWith sets f as a transformation applied to struct field names — for
+// both value fields (via form's Decoder.KeysWith) and file fields — to
+// obtain their form keys, and returns the Decoder. Fields with an explicit
+// tag are exempt: tags always name keys verbatim. Passing nil clears the
+// transformation; see form.Decoder.KeysWith for the full mapper contract.
+func (d *Decoder) KeysWith(f func(string) string) *Decoder {
+	d.keyFn = f
+	d.fd.KeysWith(f)
 	return d
 }
 
@@ -170,14 +186,14 @@ func (d *Decoder) filesLimit() int {
 // must be a non-nil pointer to a struct.
 func (d *Decoder) DecodeForm(dst interface{}, mf *multipart.Form) error {
 	if mf == nil {
-		return errors.New("form/multipart: nil *multipart.Form")
+		return form.NewError(form.OpDecode, form.KindUnsupported, nil, "form/multipart: nil *multipart.Form")
 	}
 	v := reflect.ValueOf(dst)
 	if v.Kind() != reflect.Ptr || v.IsNil() {
-		return errors.New("form/multipart: dst must be a non-nil pointer to a struct")
+		return form.NewError(form.OpDecode, form.KindUnsupported, nil, "form/multipart: dst must be a non-nil pointer to a struct")
 	}
 	if v.Elem().Kind() != reflect.Struct {
-		return errors.New("form/multipart: dst must point to a struct")
+		return form.NewError(form.OpDecode, form.KindUnsupported, nil, "form/multipart: dst must point to a struct")
 	}
 	if len(mf.Value) > 0 {
 		if err := d.fd.DecodeValues(dst, url.Values(mf.Value)); err != nil {
@@ -192,8 +208,11 @@ func (d *Decoder) DecodeForm(dst interface{}, mf *multipart.Form) error {
 // data in memory and the remainder in temporary files — and decodes the
 // result into dst, which must be a non-nil pointer to a struct.
 func (d *Decoder) DecodeRequest(dst interface{}, r *http.Request, maxMemory int64) error {
+	if r == nil {
+		return form.NewError(form.OpDecode, form.KindUnsupported, nil, "form/multipart: nil *http.Request")
+	}
 	if err := r.ParseMultipartForm(maxMemory); err != nil {
-		return err
+		return form.NewError(form.OpDecode, form.KindSyntax, err, err.Error())
 	}
 	return d.DecodeForm(dst, r.MultipartForm)
 }
@@ -212,7 +231,7 @@ func DecodeRequest(dst interface{}, r *http.Request, maxMemory int64) error {
 
 // setFiles maps each file part onto the matching struct field of v.
 func (d *Decoder) setFiles(v reflect.Value, files map[string][]*multipart.FileHeader) error {
-	fields := fieldsByName(v)
+	fields := fieldsByName(v, d.keyFn)
 	for name, fhs := range files {
 		if len(fhs) == 0 {
 			continue
@@ -222,7 +241,8 @@ func (d *Decoder) setFiles(v reflect.Value, files map[string][]*multipart.FileHe
 			if d.ignoreUnknown {
 				continue
 			}
-			return fmt.Errorf("form/multipart: unknown file key %q; set Decoder.IgnoreUnknownKeys(true) to skip unmodeled fields", name)
+			return form.NewError(form.OpDecode, form.KindUnknownKey, nil,
+				fmt.Sprintf("form/multipart: unknown file key %q; set Decoder.IgnoreUnknownKeys(true) to skip unmodeled fields", name))
 		}
 		switch fv.Type() {
 		case fileHeaderPtr:
@@ -255,7 +275,8 @@ func (d *Decoder) setFiles(v reflect.Value, files map[string][]*multipart.FileHe
 			if d.ignoreUnknown {
 				continue
 			}
-			return fmt.Errorf("form/multipart: cannot decode file %q into field of type %v", name, fv.Type())
+			return form.NewError(form.OpDecode, form.KindUnsupported, nil,
+				fmt.Sprintf("form/multipart: cannot decode file %q into field of type %v", name, fv.Type()))
 		}
 	}
 	return nil
@@ -270,7 +291,7 @@ func (d *Decoder) readFile(fh *multipart.FileHeader) ([]byte, error) {
 	}
 	f, err := fh.Open()
 	if err != nil {
-		return nil, err
+		return nil, form.NewError(form.OpDecode, form.KindIO, err, err.Error())
 	}
 	defer f.Close()
 
@@ -281,7 +302,7 @@ func (d *Decoder) readFile(fh *multipart.FileHeader) ([]byte, error) {
 	}
 	bs, err := io.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return nil, form.NewError(form.OpDecode, form.KindIO, err, err.Error())
 	}
 	if limit >= 0 && int64(len(bs)) > limit {
 		return nil, tooLarge(fh, limit)
@@ -290,16 +311,16 @@ func (d *Decoder) readFile(fh *multipart.FileHeader) ([]byte, error) {
 }
 
 func tooLarge(fh *multipart.FileHeader, limit int64) error {
-	return fmt.Errorf("form/multipart: file %q exceeds the maximum size (%d bytes) read into memory; see Decoder.MaxFileSize, or use a *multipart.FileHeader field to stream it", fh.Filename, limit)
+	return form.NewError(form.OpDecode, form.KindLimit, nil, fmt.Sprintf("form/multipart: file %q exceeds the maximum size (%d bytes) read into memory; see Decoder.MaxFileSize, or use a *multipart.FileHeader field to stream it", fh.Filename, limit))
 }
 
 func tooManyFiles(name string, n, limit int) error {
-	return fmt.Errorf("form/multipart: key %q carries %d files, exceeding the maximum (%d); see Decoder.MaxFiles", name, n, limit)
+	return form.NewError(form.OpDecode, form.KindLimit, nil, fmt.Sprintf("form/multipart: key %q carries %d files, exceeding the maximum (%d); see Decoder.MaxFiles", name, n, limit))
 }
 
 // fieldsByName indexes the settable, exported fields of struct value v by
 // their decoded name (per fieldName).
-func fieldsByName(v reflect.Value) map[string]reflect.Value {
+func fieldsByName(v reflect.Value, keyFn func(string) string) map[string]reflect.Value {
 	fields := map[string]reflect.Value{}
 	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {
@@ -311,7 +332,7 @@ func fieldsByName(v reflect.Value) map[string]reflect.Value {
 		if !fv.CanSet() {
 			continue
 		}
-		name := fieldName(sf)
+		name := fieldName(sf, keyFn)
 		if name == "-" {
 			continue
 		}
@@ -321,14 +342,18 @@ func fieldsByName(v reflect.Value) map[string]reflect.Value {
 }
 
 // fieldName reports the key under which struct field sf is decoded: the name
-// in its `form` tag, else its `json` tag, else the field's own name.
-func fieldName(sf reflect.StructField) string {
+// in its `form` tag, else its `json` tag, else the field's own name — the
+// latter transformed by keyFn when one is set (tags are exempt).
+func fieldName(sf reflect.StructField, keyFn func(string) string) string {
 	for _, key := range [2]string{"form", "json"} {
 		if tag := sf.Tag.Get(key); tag != "" {
 			if name := strings.SplitN(tag, ",", 2)[0]; name != "" {
 				return name
 			}
 		}
+	}
+	if keyFn != nil {
+		return keyFn(sf.Name)
 	}
 	return sf.Name
 }

--- a/multipart/multipart_test.go
+++ b/multipart/multipart_test.go
@@ -6,10 +6,14 @@ package multipart
 
 import (
 	"bytes"
+	"errors"
 	"mime/multipart"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode"
+
+	"github.com/ajg/form"
 )
 
 type target struct {
@@ -258,5 +262,95 @@ func TestDecodeFormErrors(t *testing.T) {
 	s := "nope"
 	if err := DecodeForm(&s, mf); err == nil {
 		t.Error("pointer to non-struct dst: expected error")
+	}
+}
+
+func TestTypedErrors(t *testing.T) {
+	body, boundary := writeMultipart(t, nil, []file{{"surprise", "s.txt", "x"}})
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst target
+	err := DecodeForm(&dst, mf)
+	var fe *form.Error
+	if err == nil || !errors.As(err, &fe) || fe.Op != form.OpDecode || fe.Kind != form.KindUnknownKey {
+		t.Errorf("unknown file key: got %v, want *form.Error KindUnknownKey", err)
+	}
+
+	body, boundary = writeMultipart(t, nil, []file{{"avatar", "big.png", strings.Repeat("x", 100)}})
+	mf = parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+	var eager eagerTarget
+	err = NewDecoder().IgnoreUnknownKeys(true).MaxFileSize(10).DecodeForm(&eager, mf)
+	if err == nil || !errors.As(err, &fe) || fe.Kind != form.KindLimit {
+		t.Errorf("oversized file: got %v, want KindLimit", err)
+	}
+
+	if err := DecodeForm(&dst, nil); err == nil || !errors.As(err, &fe) || fe.Kind != form.KindUnsupported {
+		t.Errorf("nil form: got %v, want KindUnsupported", err)
+	}
+}
+
+func TestKeysWithFilesAndValues(t *testing.T) {
+	snake := func(s string) string {
+		var b strings.Builder
+		for i, r := range s {
+			if unicode.IsUpper(r) && i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(unicode.ToLower(r))
+		}
+		return b.String()
+	}
+	type profile struct {
+		HomeCity    string                // value field via keyFn
+		AvatarImage *multipart.FileHeader // file field via keyFn
+		Tagged      []byte                `form:"exact"` // tags stay verbatim
+	}
+	body, boundary := writeMultipart(t,
+		[]field{{"home_city", "lisbon"}},
+		[]file{
+			{"avatar_image", "a.png", "img"},
+			{"exact", "t.bin", "tagged"},
+		},
+	)
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst profile
+	if err := NewDecoder().KeysWith(snake).DecodeForm(&dst, mf); err != nil {
+		t.Fatal(err)
+	}
+	if dst.HomeCity != "lisbon" {
+		t.Errorf("value via keyFn: got %+v", dst.HomeCity)
+	}
+	if dst.AvatarImage == nil || dst.AvatarImage.Filename != "a.png" {
+		t.Errorf("file via keyFn: got %+v", dst.AvatarImage)
+	}
+	if string(dst.Tagged) != "tagged" {
+		t.Errorf("tagged file: got %q", dst.Tagged)
+	}
+}
+
+func TestKeysWithNilClears(t *testing.T) {
+	snake := func(s string) string { return strings.ToLower(s) }
+	body, boundary := writeMultipart(t, []field{{"HomeCity", "lisbon"}}, nil)
+	mf := parseForm(t, body, boundary)
+	defer mf.RemoveAll()
+
+	var dst struct{ HomeCity string }
+	d := NewDecoder().KeysWith(snake)
+	d.KeysWith(nil)
+	if err := d.DecodeForm(&dst, mf); err != nil || dst.HomeCity != "lisbon" {
+		t.Errorf("nil should clear the mapper: err=%v v=%+v", err, dst)
+	}
+}
+
+func TestNilRequest(t *testing.T) {
+	var dst struct{ A string }
+	err := DecodeRequest(&dst, nil, 1<<20)
+	var fe *form.Error
+	if err == nil || !errors.As(err, &fe) || fe.Kind != form.KindUnsupported {
+		t.Errorf("nil request: got %v, want typed KindUnsupported (not a panic)", err)
 	}
 }


### PR DESCRIPTION
Brings `form/multipart` to parity with the parent package's v1.9 features, completing what `NewError` was built for.

**Typed errors.** Every error the subpackage mints is now a `*form.Error` with `Op: form.OpDecode` and an appropriate `Kind` — `KindUnknownKey` (unmodeled file key), `KindLimit` (`MaxFileSize`/`MaxFiles`), `KindUnsupported` (nil/invalid destination, file aimed at an unsupported field type), `KindIO` (opening/reading a part), `KindSyntax` (a malformed body rejected by `ParseMultipartForm`, wrapping the underlying error). Message strings are unchanged from v1.8.0, so string-matching code is unaffected; value-field errors already arrived typed via the embedded form decoder.

**KeysWith passthrough.** `Decoder.KeysWith` now exists here too, applying the mapper both to value fields (delegated to `form.Decoder.KeysWith`) and to file-field matching — closing the gap where a snake_case mapper would apply to half a struct. Tags remain exempt and verbatim, as in form.

Also guards `DecodeRequest` against a nil `*http.Request` (previously an uncaught nil-pointer panic — the last process-crashing input in the module) and documents that `KeysWith(nil)` clears the mapper.

Tests pin the Kind of each error class, a mixed value+file+tagged-field decode through a snake_case mapper, nil-request rejection, and nil-mapper clearing.