### PR TITLE
Reconcile README with v1.9 behavior; replace TODO.md with Future Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Like other encoding packages, `form` supports the following options for fields:
  - `` `form:",omitempty"` ``: Elides the field during encoding if it is empty (typically meaning equal to the type's zero value.)
  - `` `form:"<name>,omitempty"` ``: The way to combine the two options above.
 
+When a field carries no `form` tag, a `json` tag, if present, is used in its
+place — convenient for structs already annotated for JSON APIs. (The
+`form/multipart` subpackage follows the same rule.)
+
 Values
 ------
 
@@ -101,6 +105,10 @@ Values of the following types are all considered simple:
  - `[]byte` (see note)
  - [`time.Time`](http://golang.org/pkg/time/#Time)
  - [`url.URL`](http://golang.org/pkg/net/url/#URL)
+ - The fixed-channel [`image/color`](http://golang.org/pkg/image/color/) types
+   when represented as hex strings (see [Colors](#colors); unlike `time.Time`
+   and `url.URL` these are dual-representation — their composite form below
+   also remains supported, and is the default when encoding)
  - An alias of any of the above
  - A pointer to any of the above
 
@@ -110,7 +118,9 @@ A composite value is one that can contain other values. Values of the following 
 
  - Maps
  - Slices; except `[]byte` (see note)
- - Structs; except [`time.Time`](http://golang.org/pkg/time/#Time) and [`url.URL`](http://golang.org/pkg/net/url/#URL)
+ - Structs; except [`time.Time`](http://golang.org/pkg/time/#Time),
+   [`url.URL`](http://golang.org/pkg/net/url/#URL) and — when written as hex
+   strings — the fixed-channel color types (see [Colors](#colors))
  - Arrays
  - An alias of any of the above
  - A pointer to any of the above
@@ -387,6 +397,21 @@ Like this package, decoding is strict by default: a value or file key that
 matches no destination field is an error. Browser submissions routinely carry
 extra fields (CSRF tokens, submit-button names); either model them or skip
 them with `fmp.NewDecoder().IgnoreUnknownKeys(true)`.
+
+Future Work
+-----------
+
+Remaining aspirations are deliberately deferred to a future v2, where some
+defaults may change: decoding is expected to become lenient about unknown
+keys by default (with strictness opt-in), hex is expected to become the
+default encoding for the fixed-channel `image/color` types, and slice
+wire-format conventions (such as PHP/Rails-style `services[]=…` or bare
+repeated keys) are candidates for an implicit-indexing rework. The
+longest-standing item — streaming encoding and decoding directly via the
+`io.Reader`/`io.Writer` instead of materializing the input, its `url.Values`
+and an intermediate tree in memory — is likewise v2-shaped: implicit indexing
+and the deterministic handling of conflicting keys are whole-input properties
+that a streaming design must either restrict or redefine.
 
 Related Work
 ------------

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,0 @@
-TODO
-====
-
-  - Improve encoding/decoding by reading/writing directly from/to the `io.Reader`/`io.Writer` when possible, rather than going through an intermediate representation (i.e. `node`) which requires more memory.


### PR DESCRIPTION
Documentation only, in two parts.

**Reconciliation.** The Values taxonomy predated this cycle and had drifted from behavior: the Simple/Composite lists now account for the fixed-channel `image/color` types (dual-representation: hex strings *and* the composite struct form, with composite remaining the encode default — unlike `time.Time`/`url.URL`, which are strictly simple), and the Field Tags section finally documents the long-standing `json`-tag fallback that both this package and `form/multipart` honor.

**Future Work replaces TODO.md.** The file is down to one item after this cycle implemented or consciously retired the rest; the remaining item — streaming via `io.Reader`/`io.Writer` — moves into a README "Future Work" section alongside the other declared v2 intentions (lenient unknown-key default, hex as default color encoding, slice wire-format conventions), with a sentence on why streaming is v2-shaped. A TODO file reads as neglect when stale; a Future Work section tells consumers which defaults may change at v2 and why — exactly what someone evaluating the library wants to know.