### PR TITLE
Add Decoder.MaxBytes, bounding raw input size

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,13 @@ resource-exhaustion denial of service (added in v1.7.2):
    with `Decoder.MaxDepth(n)`: `n > 0` sets the limit, `n < 0` disables it (trusted
    input only), and the zero value keeps the default.
 
+ - **Input size.** `Decode` reads its entire input into memory before parsing.
+   For untrusted streams, bound it with `Decoder.MaxBytes(n)` (a larger input
+   is rejected) or wrap the reader (e.g. with `http.MaxBytesReader`). Unlike
+   the bounds above, this one is off by default, because a built-in cap would
+   break legitimately large trusted inputs; set it explicitly when decoding
+   untrusted data.
+
 The package-level `DecodeString` and `DecodeValues` helpers use these safe defaults.
 If you decode large but trusted input and hit a limit, raise or disable it via the
 methods above.

--- a/decode.go
+++ b/decode.go
@@ -27,6 +27,7 @@ type Decoder struct {
 	ignoreCase    bool
 	maxSize       int
 	maxDepth      int
+	maxBytes      int64
 	keyFn         func(string) string
 }
 
@@ -55,9 +56,17 @@ func (d Decoder) Decode(dst interface{}) error {
 	if d.r == nil {
 		return NewError(OpDecode, KindIO, nil, "form: cannot decode from a nil reader")
 	}
-	bs, err := io.ReadAll(d.r)
+	r := d.r
+	if d.maxBytes > 0 {
+		r = io.LimitReader(r, d.maxBytes+1)
+	}
+	bs, err := io.ReadAll(r)
 	if err != nil {
 		return wrapKind(OpDecode, KindIO, err)
+	}
+	if d.maxBytes > 0 && int64(len(bs)) > d.maxBytes {
+		return NewError(OpDecode, KindLimit, nil,
+			"form: input exceeds the maximum size ("+strconv.FormatInt(d.maxBytes, 10)+" bytes); see Decoder.MaxBytes")
 	}
 	vs, err := url.ParseQuery(string(bs))
 	if err != nil {
@@ -128,6 +137,18 @@ func (d *Decoder) KeysWith(f func(string) string) *Decoder {
 // uses the built-in default.
 func (d *Decoder) MaxDepth(maxDepth int) *Decoder {
 	d.maxDepth = maxDepth
+	return d
+}
+
+// MaxBytes bounds how many bytes of input Decode will read into memory
+// before parsing, guarding against memory exhaustion from an oversized
+// payload. A value > 0 sets the bound; a larger input yields a KindLimit
+// error. Values <= 0 leave input unbounded — the default, for compatibility;
+// bound untrusted streams explicitly here or by wrapping the reader (e.g.
+// with http.MaxBytesReader). It applies only to Decode: DecodeString and
+// DecodeValues receive already-materialized input.
+func (d *Decoder) MaxBytes(maxBytes int64) *Decoder {
+	d.maxBytes = maxBytes
 	return d
 }
 

--- a/maxbytes_test.go
+++ b/maxbytes_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// MaxBytes completes the resource-bounding triad (with MaxSize and MaxDepth):
+// it caps how much raw input Decode will buffer before parsing.
+func TestMaxBytes(t *testing.T) {
+	payload := "a=" + strings.Repeat("x", 98) // 100 bytes total
+
+	var dst struct {
+		A string `form:"a"`
+	}
+
+	// Over the bound: a typed limit error.
+	err := NewDecoder(strings.NewReader(payload)).MaxBytes(99).Decode(&dst)
+	var fe *Error
+	if err == nil || !errors.As(err, &fe) || fe.Kind != KindLimit {
+		t.Errorf("over bound: got %v, want KindLimit", err)
+	}
+
+	// Exactly at the bound: decodes.
+	if err := NewDecoder(strings.NewReader(payload)).MaxBytes(100).Decode(&dst); err != nil {
+		t.Errorf("at bound: %v", err)
+	} else if len(dst.A) != 98 {
+		t.Errorf("at bound: got %d bytes", len(dst.A))
+	}
+
+	// Default is unbounded (compatibility): the same input decodes with no
+	// bound configured.
+	if err := NewDecoder(strings.NewReader(payload)).Decode(&dst); err != nil {
+		t.Errorf("default: %v", err)
+	}
+
+	// The bound does not apply to already-materialized input.
+	d := NewDecoder(nil).MaxBytes(1)
+	if err := d.DecodeString(&dst, payload); err != nil {
+		t.Errorf("DecodeString exempt: %v", err)
+	}
+}


### PR DESCRIPTION
Completes the resource-bounding triad. `MaxSize` and `MaxDepth` bound *amplification* — what a small input can make the decoder allocate — but `Decode` begins with an unbounded `io.ReadAll`, so a sufficiently large body exhausts memory before any existing limit engages. `Decoder.MaxBytes(n)` caps how much raw input `Decode` buffers; a larger input yields a `KindLimit` error (enforced via `io.LimitReader` against actual bytes read, not a header claim).

One deliberate asymmetry with its siblings: **the default is unbounded.** MaxSize/MaxDepth could ship safe defaults because their attacks need only tiny inputs, so real traffic was unaffected; a built-in byte cap would instead break legitimately large trusted inputs that decode fine today. So this bound is opt-in, the README's Limits section says so explicitly (recommending `MaxBytes` or `http.MaxBytesReader` for untrusted streams), and a bounded default is a candidate for the v2 defaults conversation. It applies only to `Decode` — `DecodeString`/`DecodeValues` receive already-materialized input.

Tests pin: over-bound rejection with `KindLimit`, exactly-at-bound success, unbounded default, and `DecodeString` exemption.