### PR TITLE
Rename Decoder/Encoder fields for readability

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -15,14 +15,14 @@ import (
 
 // NewDecoder returns a new form Decoder.
 func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r, d: defaultDelimiter, e: defaultEscape}
+	return &Decoder{reader: r, delimiter: defaultDelimiter, escape: defaultEscape}
 }
 
 // Decoder decodes data from a form (application/x-www-form-urlencoded).
 type Decoder struct {
-	r             io.Reader
-	d             rune
-	e             rune
+	reader        io.Reader
+	delimiter     rune
+	escape        rune
 	ignoreUnknown bool
 	ignoreCase    bool
 	maxSize       int
@@ -36,7 +36,7 @@ type Decoder struct {
 // from the escape (validated when decoding) and should not occur unescaped
 // within keys.
 func (d *Decoder) DelimitWith(r rune) *Decoder {
-	d.d = r
+	d.delimiter = r
 	return d
 }
 
@@ -44,7 +44,7 @@ func (d *Decoder) DelimitWith(r rune) *Decoder {
 // by Decoder d and returns the latter; it is '\\' by default. The escape must
 // differ from the delimiter (validated when decoding).
 func (d *Decoder) EscapeWith(r rune) *Decoder {
-	d.e = r
+	d.escape = r
 	return d
 }
 
@@ -52,16 +52,16 @@ func (d *Decoder) EscapeWith(r rune) *Decoder {
 // configuration, and returns the Decoder. It allows a configured Decoder to
 // be reused (e.g. via sync.Pool) without reallocation.
 func (d *Decoder) Reset(r io.Reader) *Decoder {
-	d.r = r
+	d.reader = r
 	return d
 }
 
 // Decode reads in and decodes form-encoded data into dst.
 func (d Decoder) Decode(dst interface{}) error {
-	if d.r == nil {
+	if d.reader == nil {
 		return NewError(OpDecode, KindIO, nil, "form: cannot decode from a nil reader")
 	}
-	r := d.r
+	r := d.reader
 	if d.maxBytes > 0 {
 		r = io.LimitReader(r, d.maxBytes+1)
 	}
@@ -219,7 +219,7 @@ func (d Decoder) decode(v reflect.Value, vs url.Values) (err error) {
 	if !v.IsValid() {
 		return NewError(OpDecode, KindUnsupported, nil, "form: dst must be a non-nil value")
 	}
-	if d.d == d.e {
+	if d.delimiter == d.escape {
 		return NewError(OpDecode, KindUnsupported, nil, "form: delimiter and escape must differ")
 	}
 	defer func() {
@@ -231,7 +231,7 @@ func (d Decoder) decode(v reflect.Value, vs url.Values) (err error) {
 	if v.Kind() == reflect.Slice {
 		return &Error{Op: OpDecode, Kind: KindUnsupported, msg: "could not decode directly into slice; use pointer to slice"}
 	}
-	d.decodeValue(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v), d.depthLimit()))
+	d.decodeValue(v, parseValues(d.delimiter, d.escape, vs, canIndexOrdinally(v), d.depthLimit()))
 	return nil
 }
 

--- a/encode.go
+++ b/encode.go
@@ -17,25 +17,25 @@ import (
 
 // NewEncoder returns a new form Encoder.
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{w: w, d: defaultDelimiter, e: defaultEscape}
+	return &Encoder{writer: w, delimiter: defaultDelimiter, escape: defaultEscape}
 }
 
 // Encoder provides a way to encode to a Writer.
 type Encoder struct {
-	w  io.Writer
-	d  rune
-	e  rune
-	z  bool
-	o  bool
-	h  bool
-	kf func(string) string
+	writer    io.Writer
+	delimiter rune
+	escape    rune
+	keepZeros bool
+	omitEmpty bool
+	hexColors bool
+	keyFn     func(string) string
 }
 
 // DelimitWith sets r as the delimiter used for composite keys by Encoder e
 // and returns the latter; it is '.' by default. The delimiter must differ
 // from the escape (validated when encoding).
 func (e *Encoder) DelimitWith(r rune) *Encoder {
-	e.d = r
+	e.delimiter = r
 	return e
 }
 
@@ -43,13 +43,13 @@ func (e *Encoder) DelimitWith(r rune) *Encoder {
 // by Encoder e and returns the latter; it is '\\' by default. The escape must
 // differ from the delimiter (validated when encoding).
 func (e *Encoder) EscapeWith(r rune) *Encoder {
-	e.e = r
+	e.escape = r
 	return e
 }
 
 // KeepZeros sets whether Encoder e should keep zero (default) values in their literal form when encoding, and returns the former; by default zero values are not kept, but are rather encoded as the empty string.
 func (e *Encoder) KeepZeros(z bool) *Encoder {
-	e.z = z
+	e.keepZeros = z
 	return e
 }
 
@@ -65,7 +65,7 @@ func (e *Encoder) KeepZeros(z bool) *Encoder {
 // into a *Error. Set the same transformation on the Decoder (see
 // Decoder.KeysWith) for values to round-trip.
 func (e *Encoder) KeysWith(f func(string) string) *Encoder {
-	e.kf = f
+	e.keyFn = f
 	return e
 }
 
@@ -75,13 +75,13 @@ func (e *Encoder) KeysWith(f func(string) string) *Encoder {
 // It is false by default, preserving the existing composite wire format for
 // current consumers. Decoding accepts both representations regardless.
 func (e *Encoder) HexColors(h bool) *Encoder {
-	e.h = h
+	e.hexColors = h
 	return e
 }
 
 // OmitEmpty sets whether Encoder e should omit empty (zero) struct fields during encoding, and returns the former; this is equivalent to having ",omitempty" on every field. By default, empty fields are included.
 func (e *Encoder) OmitEmpty(o bool) *Encoder {
-	e.o = o
+	e.omitEmpty = o
 	return e
 }
 
@@ -89,25 +89,25 @@ func (e *Encoder) OmitEmpty(o bool) *Encoder {
 // configuration, and returns the Encoder. It allows a configured Encoder to
 // be reused (e.g. via sync.Pool) without reallocation.
 func (e *Encoder) Reset(w io.Writer) *Encoder {
-	e.w = w
+	e.writer = w
 	return e
 }
 
 // Encode encodes dst as form and writes it out using the Encoder's Writer.
 func (e Encoder) Encode(dst interface{}) error {
-	if e.w == nil {
+	if e.writer == nil {
 		return NewError(OpEncode, KindIO, nil, "form: cannot encode to a nil writer")
 	}
-	if e.d == e.e {
+	if e.delimiter == e.escape {
 		return NewError(OpEncode, KindUnsupported, nil, "form: delimiter and escape must differ")
 	}
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, encOpts{keepZeros: e.z, omitEmpty: e.o, hexColors: e.h, keyFn: e.kf})
+	n, err := encodeToNode(v, encOpts{keepZeros: e.keepZeros, omitEmpty: e.omitEmpty, hexColors: e.hexColors, keyFn: e.keyFn})
 	if err != nil {
 		return err
 	}
-	s := n.values(e.d, e.e).Encode()
-	l, err := io.WriteString(e.w, s)
+	s := n.values(e.delimiter, e.escape).Encode()
+	l, err := io.WriteString(e.writer, s)
 	switch {
 	case err != nil:
 		return wrapKind(OpEncode, KindIO, err)


### PR DESCRIPTION
Rename-only chore, zero behavior change: the single-letter private fields on `Decoder` (`r`, `d`, `e`) and `Encoder` (`w`, `d`, `e`, `z`, `o`, `h`, `kf`) become `reader`/`writer`/`delimiter`/`escape`/`keepZeros`/`omitEmpty`/`hexColors`/`keyFn`, matching the longer names the newer fields (`maxSize`, `maxDepth`, `maxBytes`, `keyFn`, `ignoreCase`, …) already use.

The principle is distance-based naming: a name should carry enough meaning for the distance between its declaration and its uses. These fields are read in methods far from the struct declaration — `if e.d == e.e` forces a lookup, `if e.delimiter == e.escape` doesn't — and the guard/validation work this cycle multiplied those distant reads. Method parameters and short-lived locals stay terse, as scoped names should.

Private fields only; no exported API, wire format, or error string is touched. `gofmt` clean, full suite green in both packages.