### PR TITLE
Fix MaxInt64 limit overflow reading input as empty

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -7,6 +7,7 @@ package form
 import (
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -62,7 +63,10 @@ func (d Decoder) Decode(dst interface{}) error {
 		return NewError(OpDecode, KindIO, nil, "form: cannot decode from a nil reader")
 	}
 	r := d.reader
-	if d.maxBytes > 0 {
+	if d.maxBytes > 0 && d.maxBytes < math.MaxInt64 {
+		// Read one byte beyond the bound to detect exceedance; at MaxInt64
+		// the +1 would overflow into a negative (empty) limit, and the
+		// bound is unexceedable anyway.
 		r = io.LimitReader(r, d.maxBytes+1)
 	}
 	bs, err := io.ReadAll(r)

--- a/maxbytes_test.go
+++ b/maxbytes_test.go
@@ -6,6 +6,7 @@ package form
 
 import (
 	"errors"
+	"math"
 	"strings"
 	"testing"
 )
@@ -43,5 +44,18 @@ func TestMaxBytes(t *testing.T) {
 	d := NewDecoder(nil).MaxBytes(1)
 	if err := d.DecodeString(&dst, payload); err != nil {
 		t.Errorf("DecodeString exempt: %v", err)
+	}
+}
+
+func TestMaxBytesMaxInt64(t *testing.T) {
+	// The bound is unexceedable, so it must behave as if unset — not
+	// overflow into silently reading nothing.
+	var dst struct{ A string }
+	d := NewDecoder(strings.NewReader("A=hello")).MaxBytes(math.MaxInt64)
+	if err := d.Decode(&dst); err != nil {
+		t.Fatal(err)
+	}
+	if dst.A != "hello" {
+		t.Errorf("input silently dropped: got %+v", dst)
 	}
 }

--- a/multipart/multipart.go
+++ b/multipart/multipart.go
@@ -37,6 +37,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -305,8 +306,10 @@ func (d *Decoder) readFile(fh *multipart.FileHeader) ([]byte, error) {
 	defer f.Close()
 
 	r := io.Reader(f)
-	if limit >= 0 {
-		// Trust the actual bytes, not just the reported Size.
+	if limit >= 0 && limit < math.MaxInt64 {
+		// Trust the actual bytes, not just the reported Size. At MaxInt64
+		// the +1 would overflow into a negative (empty) limit, and the
+		// bound is unexceedable anyway.
 		r = io.LimitReader(f, limit+1)
 	}
 	bs, err := io.ReadAll(r)

--- a/multipart/multipart_test.go
+++ b/multipart/multipart_test.go
@@ -7,6 +7,7 @@ package multipart
 import (
 	"bytes"
 	"errors"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -395,5 +396,45 @@ func TestNotMultipartKind(t *testing.T) {
 	}
 	if !errors.Is(err, http.ErrNotMultipart) {
 		t.Errorf("underlying http.ErrNotMultipart not reachable: %v", err)
+	}
+}
+
+func TestMaxFileSizeMaxInt64(t *testing.T) {
+	// The bound is unexceedable, so it must behave as if unbounded — not
+	// overflow into silently reading files as empty.
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	fw, _ := w.CreateFormFile("doc", "a.txt")
+	fw.Write([]byte("hello file"))
+	w.Close()
+
+	req, _ := http.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	var dst struct {
+		Doc []byte `form:"doc"`
+	}
+	if err := DecodeRequest(&dst, req, 1<<20); err != nil {
+		t.Fatal(err)
+	}
+	// Sanity of the fixture itself before the edge case:
+	if string(dst.Doc) != "hello file" {
+		t.Fatalf("fixture broken: %q", dst.Doc)
+	}
+
+	body.Reset()
+	w = multipart.NewWriter(&body)
+	fw, _ = w.CreateFormFile("doc", "a.txt")
+	fw.Write([]byte("hello file"))
+	w.Close()
+	req, _ = http.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	dst.Doc = nil
+	if err := NewDecoder().MaxFileSize(math.MaxInt64).DecodeRequest(&dst, req, 1<<20); err != nil {
+		t.Fatal(err)
+	}
+	if string(dst.Doc) != "hello file" {
+		t.Errorf("file silently truncated: got %q", dst.Doc)
 	}
 }


### PR DESCRIPTION
Found by an adversarial audit of the new bounds: `Decoder.MaxBytes(math.MaxInt64)` — and its sibling `multipart.Decoder.MaxFileSize(math.MaxInt64)` — read *nothing* instead of everything. Both implementations read one byte beyond the bound to detect exceedance, so at `MaxInt64` the `+1` overflows into a negative `io.LimitReader` limit, which returns immediate EOF: the decode "succeeds" against silently empty input (zero-valued struct, empty file contents). A user writing `MaxInt64` to mean "effectively unbounded" would get exactly the opposite.

The fix skips the sentinel-byte wrapping when the bound is `MaxInt64`, where it is unexceedable anyway — behavior there is now identical to the bound being unset, which is what the value means. All other values are unaffected. Regression tests pin both entry points.

The rest of the audit found nothing: sparse huge indices stay allocation-bounded, 100k-deep key paths fail typed at the depth limit without stack exhaustion, hostile map keys (delimiters, escapes, NULs) round-trip inertly with no structure injection, panicking user `TextUnmarshaler`/`TextMarshaler`/key-mapper code is contained to typed errors in both directions, encode cycles via maps and pointers are caught, scalar/composite key conflicts are deterministic, and 1.4M fuzz executions produced no crashers.