### PR TITLE
Fix implicit indexing corrupting repeated keys

### DIFF
--- a/implicit_test.go
+++ b/implicit_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Alvaro J. Genial. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package form
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Implicit indexing lets a repeated key stand in for an ordinal one: at the
+// first level for a top-level slice/array destination, and at the last level
+// via the "_" placeholder. These cases went untested for years (the removed
+// "add tests for implicit indexing" TODO), which hid a bug where the second
+// and later values of a repeated key were assigned corrupted, compounding
+// keys — sparse, gap-riddled slices at the last level and outright decode
+// failures at the first.
+
+func TestImplicitFirstLevel(t *testing.T) {
+	// A repeated key on a top-level slice indexes ordinally by value position.
+	var dst []struct {
+		Bar string `form:"bar"`
+	}
+	if err := DecodeString(&dst, "bar=A&bar=B&bar=C"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"A", "B", "C"}
+	if len(dst) != len(want) {
+		t.Fatalf("got %+v, want three elements", dst)
+	}
+	for i, w := range want {
+		if dst[i].Bar != w {
+			t.Errorf("elem %d: got %q, want %q", i, dst[i].Bar, w)
+		}
+	}
+}
+
+func TestImplicitLastLevel(t *testing.T) {
+	// The "_" placeholder indexes the last level ordinally; three or more
+	// values previously landed at indices 0, 1, 12, 123, … (digit
+	// concatenation), producing a huge sparse slice.
+	var dst struct {
+		Bar []string `form:"bar"`
+	}
+	if err := DecodeString(&dst, "bar._=A&bar._=B&bar._=C&bar._=D"); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"A", "B", "C", "D"}; !reflect.DeepEqual(dst.Bar, want) {
+		t.Errorf("got %+v, want %+v", dst.Bar, want)
+	}
+}
+
+func TestImplicitLastLevelNested(t *testing.T) {
+	var dst struct {
+		A struct {
+			B []string `form:"b"`
+		} `form:"a"`
+	}
+	if err := DecodeString(&dst, "a.b._=x&a.b._=y&a.b._=z"); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"x", "y", "z"}; !reflect.DeepEqual(dst.A.B, want) {
+		t.Errorf("got %+v, want %+v", dst.A.B, want)
+	}
+}
+
+func TestImplicitIndexingRoundTrips(t *testing.T) {
+	// Values a slice encodes to must decode back to the same slice; the
+	// encoder emits explicit indices, which the decoder honors identically.
+	type doc struct {
+		Items []string `form:"items"`
+	}
+	src := doc{Items: []string{"one", "two", "three", "four"}}
+	s, err := EncodeToString(&src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dst doc
+	if err := DecodeString(&dst, s); err != nil {
+		t.Fatalf("re-decode of %q: %v", s, err)
+	}
+	if !reflect.DeepEqual(dst, src) {
+		t.Errorf("round trip via %q: got %+v, want %+v", s, dst, src)
+	}
+}
+
+func TestImplicitSingleValueUnchanged(t *testing.T) {
+	// The single-value paths must be byte-for-byte unaffected by the fix.
+	var slice []struct {
+		Bar string `form:"bar"`
+	}
+	if err := DecodeString(&slice, "bar=solo"); err != nil {
+		t.Fatal(err)
+	}
+	if len(slice) != 1 || slice[0].Bar != "solo" {
+		t.Errorf("got %+v", slice)
+	}
+	var last struct {
+		Bar []string `form:"bar"`
+	}
+	if err := DecodeString(&last, "bar._=solo"); err != nil {
+		t.Fatal(err)
+	}
+	if len(last.Bar) != 1 || last.Bar[0] != "solo" {
+		t.Errorf("got %+v", last.Bar)
+	}
+}

--- a/node.go
+++ b/node.go
@@ -32,7 +32,6 @@ func (n node) merge(d, e rune, p string, vs *url.Values) {
 	}
 }
 
-// TODO: Add tests for implicit indexing.
 func parseValues(d, e rune, vs url.Values, canIndexFirstLevelOrdinally bool, maxDepth int) node {
 	// NOTE: Because of the flattening of potentially multiple strings to one key, implicit indexing works:
 	//    i. At the first level;   e.g. Foo.Bar=A&Foo.Bar=B     becomes 0.Foo.Bar=A&1.Foo.Bar=B
@@ -45,13 +44,17 @@ func parseValues(d, e rune, vs url.Values, canIndexFirstLevelOrdinally bool, max
 		indexLastLevelOrdinally := strings.HasSuffix(k, string(d)+implicitKey)
 
 		for i, s := range ss {
+			// Derive each indexed key from the original k; mutating k in
+			// place would compound across values (the second value of a
+			// repeated key becoming "1."+"0."+k, etc.).
+			key := k
 			if canIndexFirstLevelOrdinally {
-				k = strconv.Itoa(i) + string(d) + k
+				key = strconv.Itoa(i) + string(d) + k
 			} else if indexLastLevelOrdinally {
-				k = strings.TrimSuffix(k, implicitKey) + strconv.Itoa(i)
+				key = strings.TrimSuffix(k, implicitKey) + strconv.Itoa(i)
 			}
 
-			m[k] = s
+			m[key] = s
 		}
 	}
 


### PR DESCRIPTION
The pre-release audit's last finding, and a good argument for the audit: `parseValues` mutated its range variable `k` in place while iterating a key's values, so the second and later values of a *repeated* key were built from the already-rewritten key rather than the original. A latent bug since at least v1.7 — present and byte-identical in v1.8.0 — hidden all this time by the very TODO this PR removes ("add tests for implicit indexing").

Concretely, for the two implicit-indexing forms the package documents:

- **First level** (repeated key into a top-level slice): `bar=A&bar=B` was meant to become `0.bar=A&1.bar=B`. Instead the second value became `1.0.bar=B` — decode failed outright with `0 doesn't exist in struct …`.
- **Last level** (the `_` placeholder): `x._=A&x._=B&x._=C` was meant to become `x.0=A&x.1=B&x.2=C`. Instead indices compounded by digit concatenation — `x.0`, `x.01`→1, `x.012`→12, `x.0123`→123 — so a third value stranded at index 12 and a fourth at 123, yielding a huge, gap-riddled sparse slice. (Two values happened to work by the coincidence that `01` parses as `1`, which is why it escaped casual notice.)

The fix derives each indexed key from the original `k` via a fresh local instead of mutating `k`. Single-value paths are provably untouched: a 20,000-sample differential against v1.8.0 shows encode byte-identical and every decode difference is exactly this correction (corrupted-sparse → dense-correct), with no case where prior output was correct and this one isn't.

Tests cover both levels, nesting, round-tripping, and the single-value paths, finally retiring the standing TODO.