### PR TITLE
Add a Code of Conduct deferring to the Go Community CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Code of Conduct
+
+This project holds its contributors to the standards described in the [Go
+Community Code of Conduct](https://go.dev/conduct): be respectful and
+considerate in issues, pull requests, and other project spaces.
+
+Reporting and enforcement for this repository rest with the maintainer — the
+contacts named in the Go document are for the Go project itself, not this one.
+To raise a concern, open an issue or contact the maintainer directly.
+Participation is ultimately at the maintainer's discretion.


### PR DESCRIPTION
Adds `CODE_OF_CONDUCT.md` to satisfy GitHub's community-profile checklist. Rather than vendor the Contributor Covenant, it points at the [Go Community Code of Conduct](https://go.dev/conduct) for the behavioral standard, and is explicit that reporting and enforcement for this repository are the maintainer's — the contacts named in the Go document serve the Go project itself, not this one.

Docs only.