### PR TITLE
Add a minimal bug-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: Bug report
+description: form or form/multipart isn't decoding or encoding the way you expect.
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproducer
+      description: >-
+        The smallest self-contained snippet that shows it — the input, the
+        target type, and the expected result. This is by far the most useful
+        thing you can include.
+      render: go
+    validations:
+      required: true
+  - type: input
+    id: form-version
+    attributes:
+      label: form version
+      description: 'e.g. v1.9.0 — from go.mod, or `go list -m github.com/ajg/form`.'
+    validations:
+      required: true
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      description: Output of `go version`.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Keep blank issues available so questions and feature ideas stay frictionless;
+# the bug form is offered, never forced.
+blank_issues_enabled: true


### PR DESCRIPTION
Adds a single GitHub issue form for bug reports (`.github/ISSUE_TEMPLATE/bug_report.yml`) that asks for the four things a decoding/encoding bug actually needs: what happened, a **minimal reproducer** (rendered as Go), the `form` version, and the Go version. The reproducer and versions are required fields — that one nudge is the whole point.

`config.yml` keeps blank issues enabled, so questions and feature ideas stay frictionless and the form is offered, never forced — consistent with CONTRIBUTING's "open an issue first for a feature."

Metadata only; no code, no module content.