### PR TITLE
Add a minimal pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+<!-- One concern per PR; see CONTRIBUTING.md. Keep this short. -->
+
+## What & why
+
+
+## Checklist
+
+- [ ] `gofmt`, `go vet`, and `go test ./...` pass (root and `./multipart`).
+- [ ] Behavior changes are pinned by a test.
+- [ ] No change to the public API, wire format, or error strings — or the PR says why.


### PR DESCRIPTION
Adds `.github/PULL_REQUEST_TEMPLATE.md` — a one-line what/why plus a three-item checklist that mirrors CONTRIBUTING: the local `gofmt`/`vet`/`test` gate (root and `./multipart`), a test pinning any behavior change, and the stability contract (no public API / wire format / error-string change without a stated reason). This very PR body is the last one written by hand before the template exists.

Metadata only; no code, no module content.