### PR TITLE
Pin CI actions to commit SHAs and harden checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,14 @@ jobs:
             matrix:
                 go-pkg: ['go_1_17', 'go_1_18', 'go_1_19', 'go_1_20', 'go_1_21', 'go_1_22', 'go_1_23', 'go_1_24', 'go_1_25', 'go_1_26']
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
 
-            - uses: nixbuild/nix-quick-install-action@v35
+            - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
             - name: Restore and cache Nix store
-              uses: nix-community/cache-nix-action@v7.0.2
+              uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
               with:
                   primary-key: nix-${{ runner.os }}-${{ matrix.go-pkg }}-${{ hashFiles('shell.nix') }}
 


### PR DESCRIPTION
Takes the one substantive supply-chain improvement from the StepSecurity bundle in #73 and leaves the rest.

**Kept (reduces attack surface, adds no new party):** the actions already used in CI — `actions/checkout`, `nixbuild/nix-quick-install-action`, `nix-community/cache-nix-action` — are now pinned to immutable commit SHAs (each verified to match the tag its comment names), so a moved or compromised tag can't inject code. `checkout` also gets `persist-credentials: false` so the token isn't left in the git config of a job that never pushes. The workflow already scopes `GITHUB_TOKEN` to `contents: read`.

**Declined (would add third parties or noise to a zero-dependency, secretless build):**
- `step-security/harden-runner` and `ossf/scorecard-action` — both add a new privileged third party into every CI run to, respectively, report egress to a vendor SaaS (in audit mode, which only observes) and compute a badge. On a build with no secrets to exfiltrate and no dependencies to audit, that trades real new trust for ~zero benefit — the exact "the thing hardening you becomes your attack surface" trap.
- `actions/dependency-review-action` — a no-op here; the module has no dependencies.
- `codeql.yml` — near-zero signal on ~1k lines of reflection code, and its scheduled runs plus Scorecard's "Maintained" check actively penalize a deliberately-paused-but-stable library.
- `.pre-commit-config.yaml` — local dev tooling (not CI), pinning ~2023-era `golangci-lint`/`gitleaks` that would only rot.

Closes #73.