### PR TITLE
Add passing OpenSSF badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Form Encoding & Decoding Package for Go, written by [Alvaro J. Genial](http://
 
 [![Build Status](https://github.com/ajg/form/actions/workflows/ci.yml/badge.svg)](https://github.com/ajg/form/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/ajg/form.svg)](https://pkg.go.dev/github.com/ajg/form)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13957/badge)](https://www.bestpractices.dev/projects/13957)
 
 Synopsis
 --------


### PR DESCRIPTION
## What & why

Add passing OpenSSF badge to make pkg.go.dev happy.

## Checklist

- [x] `gofmt`, `go vet`, and `go test ./...` pass (root and `./multipart`).
- n/a ~Behavior changes are pinned by a test.~
- n/a ~No change to the public API, wire format, or error strings — or the PR says why.~
